### PR TITLE
travis Update Travis distro and fix all issues caused by this

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-dist: trusty
+dist: xenial
 addons:
   chrome: stable
 language: python
 sudo: required
 python:
-    - "3.4"
+    - "3.5"
 
 before_script:
     - sleep 10
@@ -12,7 +12,8 @@ before_script:
 before_install:
     - "curl -O https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/deb/elasticsearch/2.1.1/elasticsearch-2.1.1.deb && sudo dpkg -i --force-confnew elasticsearch-2.1.1.deb"
     - "sudo service elasticsearch start"
-    - "wget https://chromedriver.storage.googleapis.com/2.36/chromedriver_linux64.zip; unzip chromedriver_linux64.zip -d chromedriver; export PATH=$PATH:`pwd`/chromedriver"
+    - "export LATEST_CHROMEDRIVER=$(wget -q -O - http://chromedriver.storage.googleapis.com/LATEST_RELEASE)"
+    - "wget http://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER/chromedriver_linux64.zip; unzip chromedriver_linux64.zip -d chromedriver; export PATH=$PATH:`pwd`/chromedriver"
 
 install: 
     - "pip install -r requirements_dev.txt"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ source .ve/bin/activate
 # Make sure you have a recent version of pip, to install binary wheel packages.
 pip install --upgrade pip
 pip install -r requirements.txt # Use requirements_dev.txt if you're installing for development.
-sudo apt-get install openjdk-7-jre
+sudo apt-get install openjdk-8-jre
 wget -O - https://packages.elasticsearch.org/GPG-KEY-elasticsearch | sudo apt-key add -
 echo 'deb http://packages.elasticsearch.org/elasticsearch/2.x/debian stable main' | sudo tee /etc/apt/sources.list.d/elasticsearch.list
 sudo apt-get update

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -315,7 +315,7 @@ def test_search_advanced_search_correct_link(provenance_dataload, server_url, br
     browser.find_element_by_class_name("large-search-icon").click()
     browser.find_element_by_class_name("advanced_search").click()
 
-    assert browser.current_url == 'http://grantnav.threesixtygiving.org/help#advanced_search'
+    assert browser.current_url == 'https://grantnav.threesixtygiving.org/help#advanced_search'
 
 
 def test_search_do_not_display_advance_search_link(provenance_dataload, server_url, browser):

--- a/grantnav/settings.py
+++ b/grantnav/settings.py
@@ -79,7 +79,7 @@ INSTALLED_APPS = (
     'favicon',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,8 @@ django-bootstrap3
 requests
 django-environ
 raven
-elasticsearch
+elasticsearch==2.3.0
+openpyxl==2.3.5 # Force this lower for flatten-tool compatibility
 -e git+https://github.com/OpenDataServices/flatten-tool.git@dceac82323271c4cc5956275481d762d81976eaf#egg=flattentool
 python-dateutil
 strict-rfc3339
@@ -12,4 +13,4 @@ django-cookie-law
 titlecase
 dealer
 django-super-favicon
-ijson
+ijson==2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,30 @@
-Django==1.11.20 # rq.filter: <1.12
-django-bootstrap3==9.1.0
-requests==2.21.0
-django-environ==0.4.0
-raven==5.23.0
+Django==1.11.27 # rq.filter: <1.12
+django-bootstrap3==12.0.1
+requests==2.22.0
+django-environ==0.4.5
+raven==6.10.0
 elasticsearch==2.3.0
+openpyxl==2.3.5
 -e git+https://github.com/OpenDataServices/flatten-tool.git@dceac82323271c4cc5956275481d762d81976eaf#egg=flattentool
-python-dateutil==2.5.3
+python-dateutil==2.8.1
 strict-rfc3339==0.7
-django-cookie-law==1.0.13
-titlecase==0.8.1
-dealer==2.0.5
-django-super-favicon==0.6.0
+django-cookie-law==2.0.2
+titlecase==0.12.0
+dealer==2.1.0
+django-super-favicon==0.6.1
 ijson==2.3
 ## The following requirements were added by pip freeze:
-certifi==2018.11.29
+certifi==2019.11.28
 chardet==3.0.4
-contextlib2==0.5.3
-django-classy-tags==0.7.2
+contextlib2==0.5.5
+django-classy-tags==0.9.0
 et-xmlfile==1.0.1
 idna==2.8
-jdcal==1.2
-jsonref==0.1
-olefile==0.46
-openpyxl==2.3.5
-Pillow==4.0.0
-pytz==2016.6.1
-schema==0.6.0
-six==1.10.0
-urllib3==1.24.1
+jdcal==1.4.1
+jsonref==0.2
+Pillow==6.2.1
+pytest-runner==5.2
+pytz==2019.3
+schema==0.7.1
+six==1.13.0
+urllib3==1.25.7

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -1,6 +1,6 @@
 -r requirements.in
 
-flake8
+flake8==2.6.2
 # flake8 requires pyflakes <1.1
 pyflakes<1.1
 #^^ rq.filter: <1.1
@@ -11,6 +11,5 @@ pytest-django
 pytest-cov
 pytest-localserver
 
-coveralls
 selenium
 libsass

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,16 +1,17 @@
-Django==1.11.20 # rq.filter: <1.12
-django-bootstrap3==9.1.0
-requests==2.21.0
-django-environ==0.4.0
-raven==5.23.0
+Django==1.11.27 # rq.filter: <1.12
+django-bootstrap3==12.0.1
+requests==2.22.0
+django-environ==0.4.5
+raven==6.10.0
 elasticsearch==2.3.0
+openpyxl==2.3.5
 -e git+https://github.com/OpenDataServices/flatten-tool.git@dceac82323271c4cc5956275481d762d81976eaf#egg=flattentool
-python-dateutil==2.5.3
+python-dateutil==2.8.1
 strict-rfc3339==0.7
-django-cookie-law==1.0.13
-titlecase==0.8.1
-dealer==2.0.5
-django-super-favicon==0.6.0
+django-cookie-law==2.0.2
+titlecase==0.12.0
+dealer==2.1.0
+django-super-favicon==0.6.1
 ijson==2.3
 
 
@@ -18,32 +19,38 @@ flake8==2.6.2
 # flake8 requires pyflakes <1.1
 pyflakes==1.0.0 # rq.filter: <1.1
 # pytest and plugins
-pytest==2.9.2
-pytest-django==3.1.2
-pytest-cov==2.3.0
-pytest-localserver==0.3.5
-coveralls==1.1
-selenium==2.53.6
-libsass==0.11.1
+pytest==5.3.2
+pytest-django==3.7.0
+pytest-cov==2.8.1
+pytest-localserver==0.5.0
+selenium==3.141.0
+libsass==0.19.4
 ## The following requirements were added by pip freeze:
-certifi==2018.11.29
+attrs==19.3.0
+certifi==2019.11.28
 chardet==3.0.4
-contextlib2==0.5.3
-coverage==4.1
-django-classy-tags==0.7.2
-docopt==0.6.2
+contextlib2==0.5.5
+coverage==5.0
+django-classy-tags==0.9.0
 et-xmlfile==1.0.1
 idna==2.8
-jdcal==1.2
-jsonref==0.1
-mccabe==0.5.0
-olefile==0.46
-openpyxl==2.3.5
-Pillow==4.0.0
-py==1.4.31
+importlib-metadata==1.3.0
+jdcal==1.4.1
+jsonref==0.2
+mccabe==0.5.3
+more-itertools==8.0.2
+packaging==19.2
+pathlib2==2.3.5
+Pillow==6.2.1
+pluggy==0.13.1
+py==1.8.0
 pycodestyle==2.0.0
-pytz==2016.6.1
-schema==0.6.0
-six==1.10.0
-urllib3==1.24.1
-Werkzeug==0.14.1
+pyparsing==2.4.5
+pytest-runner==5.2
+pytz==2019.3
+schema==0.7.1
+six==1.13.0
+urllib3==1.25.7
+wcwidth==0.1.7
+Werkzeug==0.16.0
+zipp==0.6.0


### PR DESCRIPTION
- Update Travis to use correct disto
- Update Travis to use correct python3 version
- Update README for correct java version for xenial
- Update chromedriver to use latest stable
- Update Django to latest version with security fix #522
- Fix Djanog settings to use MIDDLEWARE instead of deprecated
MIDDLEWARE_CLASSES (pytest-django errors on this)
- Fix floating versions in requirements*.in
- Fix test that checks urls http -> https
- Fix openpyxl version related issue #526
- Remove coveralls Not used and not compatible version with pytest-cov