### PR TITLE
dataload: import_to_elasticsearch: Remove dynamic mapping

### DIFF
--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -77,7 +77,12 @@ def maybe_create_index(index_name=ES_INDEX):
     # (the rest will be auto inferred from the data we feed in)
     #
     # See issue #503 for why we do this for a non-standard field (Reference)
+    # Fields must appear here to be indexed
     mappings = {
+        "date_detection": False,
+        "numeric_detection": False,
+        "dynamic": False,
+
         "properties": {
             "id": {"type": "keyword"},
             "filename": {"type": "keyword"},
@@ -205,7 +210,7 @@ def maybe_create_index(index_name=ES_INDEX):
                     "language": "possessive_english"
                 }
             }
-        }
+        },
     }
 
     # Create it

--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -137,6 +137,9 @@ def maybe_create_index(index_name=ES_INDEX):
                     "streetAddress": {
                         "type": "text", "analyzer": "english_with_folding"
                     },
+                    "description": {
+                        "type": "text", "analyzer": "english_with_folding"
+                    },
                     "id_and_name": {
                         "type": "keyword"
                     }
@@ -165,6 +168,9 @@ def maybe_create_index(index_name=ES_INDEX):
                     "streetAddress": {
                         "type": "text", "analyzer": "english_with_folding"
                     },
+                    "department": {
+                        "type": "text", "analyzer": "english_with_folding"
+                    },
                     "id_and_name": {
                         "type": "keyword"
                     }
@@ -174,7 +180,14 @@ def maybe_create_index(index_name=ES_INDEX):
                 "properties": {
                     "geographic code (from GIFTS)": {"type": "text"}
                 }
-            }
+            },
+            "grantProgramme": {
+                "properties": {
+                    "title": {
+                        "type": "text", "analyzer": "english_with_folding"
+                    }
+                }
+            },
         }
     }
 


### PR DESCRIPTION
As we don't restrict what fields are added to publisher's data use our mappings as the definitive list and ignore all other fields unless explicitly added to
the mapping.

https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/529