### PR TITLE
provenance: Make FileNotFoundError non-fatal to application

### DIFF
--- a/grantnav/provenance.py
+++ b/grantnav/provenance.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from collections import OrderedDict
 import json
 import copy
+import warnings
 
 by_publisher = OrderedDict()
 by_identifier = {}
@@ -9,16 +10,19 @@ by_identifier = {}
 datasets = []
 
 if settings.PROVENANCE_JSON:
-    with open(settings.PROVENANCE_JSON) as fp:
-        datasets = json.load(fp)
+    try:
+        with open(settings.PROVENANCE_JSON) as fp:
+            datasets = json.load(fp)
 
-    for dataset in datasets:
-        prefix = dataset['publisher']['prefix']
-        if prefix not in by_publisher:
-            by_publisher[prefix] = copy.deepcopy(dataset['publisher'])
-            by_publisher[prefix]['datasets'] = []
-        by_publisher[prefix]['datasets'].append(dataset)
-        by_identifier[dataset.get('identifier')] = dataset
+        for dataset in datasets:
+            prefix = dataset['publisher']['prefix']
+            if prefix not in by_publisher:
+                by_publisher[prefix] = copy.deepcopy(dataset['publisher'])
+                by_publisher[prefix]['datasets'] = []
+            by_publisher[prefix]['datasets'].append(dataset)
+            by_identifier[dataset.get('identifier')] = dataset
+    except FileNotFoundError as e:
+        warnings.warn(e)
 
 
 def identifier_from_filename(filename):


### PR DESCRIPTION
Make sure that GrantNav can still run if the provenance file specified
disappears. This can happen if the source data breaks for some reason
(e.g. download failed/interrupted or datastore error)

Fixes https://github.com/ThreeSixtyGiving/grantnav/issues/552