### PR TITLE
templates: help: Remove broken link to stats page

### DIFF
--- a/grantnav/frontend/templates/help.html
+++ b/grantnav/frontend/templates/help.html
@@ -120,7 +120,7 @@
     </li>
   </ul>
 
-  <p>{% blocktrans %}The field names used must match the machine-readable field names in the data. You can find a list of field names in use on the <a href="/stats">stats page</a>{% endblocktrans %}.</p>
+  <p>{% blocktrans %}The field names used must match the machine-readable field names in the data{% endblocktrans %}.</p>
 
   <h3 id="ranges">{% trans "Ranges" %}</h3>
   <h4>{% trans "Dates" %}</h4>


### PR DESCRIPTION
Fixes issue  https://github.com/ThreeSixtyGiving/grantnav/issues/528