### PR TITLE
dataload: import_to_elasticsearch: If error from ES raise an exception

### DIFF
--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -228,8 +228,12 @@ def maybe_create_index(index_name=ES_INDEX):
 
     # Create it
     result = es.indices.create(index=index_name, body={"mappings": mappings, "settings": settings}, ignore=[400])
-    if 'error' in result and result['error']['reason'] == 'already exists':
-        print('Updating existing index')
+    if 'error' in result:
+        if 'already exists' in result['error']['reason']:
+            print('Updating existing index')
+        else:
+            pprint(result)
+            raise Exception("Creating index failed")
     else:
         pprint(result)
 


### PR DESCRIPTION
This helps us to abort any further process as this will generate the
correct exit status and cause the shell script that this is usually
triggered from to abort too.

https://github.com/ThreeSixtyGiving/grantnav/issues/562