### PR TITLE
frontend: templates: base: add disableCookies to Matomo config

### DIFF
--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -62,6 +62,7 @@
       var _paq = _paq || [];
       {% block extrapiwik %}{% endblock %}
       _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+      _paq.push(['disableCookies']);
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {


### PR DESCRIPTION
We're not using cookie based analytics so disable this client side.