### PR TITLE
templates: grant: Update link to the zero value help text

### DIFF
--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -82,7 +82,7 @@
                 <td>
                   {{grant}}
                   {% if key == "Amount Awarded" and grant == 0 %}
-                    <a href="/help#zero_value_grants"><img src="/static/images/icon-help-50.png" width="15" height="15" id="zero_value_grant_help_link"></a>
+                    <a href="https://help.grantnav.threesixtygiving.org/en/latest/search_results.html?#some-grantmakers-publish-grants-with-0-or-negative-values"><img src="/static/images/icon-help-50.png" width="15" height="15" id="zero_value_grant_help_link"></a>
                   {% endif %}
                 </td>
                 {% endif %}

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -440,7 +440,7 @@ def test_amount_awarded_facet(provenance_dataload, server_url, browser):
 def test_zero_grant_info_link_present(provenance_dataload, server_url, browser, path):
     browser.get(server_url + path)
     browser.find_element_by_id("zero_value_grant_help_link").click()
-    assert browser.current_url == server_url + '/help#zero_value_grants'
+    assert browser.current_url == "https://help.grantnav.threesixtygiving.org/en/latest/search_results.html?#some-grantmakers-publish-grants-with-0-or-negative-values"
 
 
 @pytest.mark.parametrize(('path'), ['/grant/360G-LBFEW-99233'])


### PR DESCRIPTION
Fixes https://github.com/ThreeSixtyGiving/grantnav/issues/668