### PR TITLE
github: issue templates: Add developer issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer.md
+++ b/.github/ISSUE_TEMPLATE/developer.md
@@ -1,0 +1,5 @@
+Include:
+- High level issue description
+- Where to see the issue on the live or dev grantnav
+- Hint as to location of the issue in the code
+- Stack trace or errors


### PR DESCRIPTION
Add a reminder for developers on what information should be included.