### PR TITLE
import_to_elasticsearch: Add retry if unable to load data

### DIFF
--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -332,7 +332,7 @@ def import_to_elasticsearch(files, clean):
                     yield grant
 
         pprint(file_name)
-        result = elasticsearch.helpers.bulk(es, grant_generator(), raise_on_error=False)
+        result = elasticsearch.helpers.bulk(es, grant_generator(), raise_on_error=False, max_retries=10, initial_backoff=5)
         pprint(result)
 
         shutil.rmtree(tmp_dir)


### PR DESCRIPTION
If the server is effectively "busy" due to it not currently having
enough memory available we can wait for the GC to happen by adding
retry and backoff - both of which a disabled unless specified.

https://github.com/ThreeSixtyGiving/grantnav/issues/746