### PR TITLE
settings: Add handler for DisallowedHost exception

### DIFF
--- a/grantnav/settings.py
+++ b/grantnav/settings.py
@@ -190,6 +190,9 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
+        },
+        'null': {
+            'class': 'logging.NullHandler',
         }
     },
     'loggers': {
@@ -197,6 +200,10 @@ LOGGING = {
             'level': 'ERROR',
             'handlers': ['console'],
             'propagate': False,
+        },
+        'django.security.DisallowedHost': {
+            "handlers": ["null"],
+            "propagate": False,
         },
         'raven': {
             'level': 'DEBUG',


### PR DESCRIPTION
Capture this exception to avoid creating so many error reports on
sentry in production.

fixes https://github.com/ThreeSixtyGiving/grantnav/issues/678