### PR TITLE
gitmodules: Change the 360-ds submodule to use https not ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 	branch = master
 [submodule "360-ds"]
 	path = 360-ds
-	url = git@github.com:ThreeSixtyGiving/360-ds.git
+	url = https://github.com/ThreeSixtyGiving/360-ds.git


### PR DESCRIPTION
This is required for the Read the Docs build to succeed.