### PR TITLE
urlencode query_string before passing it to Insights

### DIFF
--- a/grantnav/frontend/templates/components/search-summary-box.html
+++ b/grantnav/frontend/templates/components/search-summary-box.html
@@ -10,7 +10,7 @@
     <div class="search-summary--description">
       {% if results.hits.total.value <= 10000 %}
         <span>To explore this dataset in more detail, open in
-          <a href="https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org{% url 'search.json' %}?{{ query_string }}" title="Download search results into 360Insights data visualiser" target="_blank">
+          <a href="https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org{% url 'search.json' %}%3F{{ query_string|urlencode }}" title="Download search results into 360Insights data visualiser" target="_blank">
             360Insights
           </a>
         </span>


### PR DESCRIPTION
I think the way Insights parses url parameters has changed in Insights NG, and they now need to be properly encoded.