### PR TITLE
dataload: Add some extra keyword fields to handle links from Insights

### DIFF
--- a/dataload/import_to_elasticsearch.py
+++ b/dataload/import_to_elasticsearch.py
@@ -212,6 +212,9 @@ def maybe_create_index(index_name=ES_INDEX):
             },
             "additional_data": {
                 "properties": {
+                    "recipientDistrictGeoCode": {
+                        "type": "keyword"
+                    },
                     "recipientDistrictName": {
                         "type": "keyword"
                     },
@@ -227,6 +230,16 @@ def maybe_create_index(index_name=ES_INDEX):
                     "recipientLocation": {
                         "type": "text"
                     },
+                    "recipientOrganizationLocation": {
+                        "properties": {
+                            "rgn": {
+                                "type": "keyword"
+                            },
+                            "ctry": {
+                                "type": "keyword"
+                            }
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
https://github.com/ThreeSixtyGiving/insights-ng/issues/16

This is so I can make a link like https://grantnav.threesixtygiving.org/search?query=+additional_data.recipientDistrictGeoCode%3AE07000008+additional_data.recipientDistrictGeoCode%3AE07000009 from Insights to GrantNav, based on the filters Insights has applied.

@kindly Does this look like a resonable thing to do?