### PR TITLE
templates: update matomo url to analytics.threesixtygiving.org

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -38,7 +38,7 @@
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//matomo.opendataservices.coop/threesixtygiving/";
+    var u="//analytics.threesixtygiving.org/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', '13']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];

--- a/fail.html
+++ b/fail.html
@@ -6761,7 +6761,7 @@ table.dataTable.dtr-inline.collapsed > tbody > tr.parent > td:first-child::befor
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);
       (function() {
-        var u="//matomo.opendataservices.coop/threesixtygiving/";
+        var u="//analytics.threesixtygiving.org/";
         _paq.push(['setTrackerUrl', u+'piwik.php']);
         _paq.push(['setSiteId', 6]);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
@@ -6769,7 +6769,7 @@ table.dataTable.dtr-inline.collapsed > tbody > tr.parent > td:first-child::befor
       })();
     </script>
     <script src="/static/cookielaw/js/cookielaw.js"></script>
-    <noscript><p><img src="//matomo.opendataservices.coop/threesixtygiving/matomo.php?idsite=6" style="border:0;" alt="" /></p></noscript>
+    <noscript><p><img src="//analytics.threesixtygiving.org/matomo.php?idsite=6" style="border:0;" alt="" /></p></noscript>
     <!-- End Piwik Code -->
     </body>
 </html>

--- a/grantnav/frontend/templates/terms.html
+++ b/grantnav/frontend/templates/terms.html
@@ -116,7 +116,7 @@
 
         <p>{% blocktrans %}Matomo also has its own opt out mechanism:{% endblocktrans %}</p>
         <!-- opt out iframe - clicking this will mean people can opt out of tracking -->
-        <iframe style="border: 1; height: 150px; width: 600px;" src="https://matomo.opendataservices.coop/threesixtygiving/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
+        <iframe style="border: 1; height: 150px; width: 600px;" src="https://analytics.threesixtygiving.org/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=en"></iframe>
 
         <p>Data processors: Open Data Services Co-operative Limited, Bytemark.</p>
         <p>No data is transferred to third countries or international organisations.</p>


### PR DESCRIPTION
PR in preparation for matomo migration