### PR TITLE
frontend: templates: Table view minor changes

### DIFF
--- a/grantnav/frontend/templates/components/grants_table_scripts.html
+++ b/grantnav/frontend/templates/components/grants_table_scripts.html
@@ -31,20 +31,21 @@
       $('#grants_datatable').dataTable({
         serverSide: true,
         responsive: true,
-        searching: true,
+        searching: false,
         autoWidth: true,
         scrollY: 400,
         scroller: true,
         order: [[0, "desc"]],
         dom: "fit",
-        scroller: {displayBuffer: 20,
-                    loadingIndicator: true},
+        scroller: {
+          displayBuffer: 20,
+          loadingIndicator: true
+        },
         language: {
-            info: "_START_ to _END_ of _TOTAL_",
-            search: "Search All Fields"
+            info: "_START_ to _END_ of _TOTAL_"
         },
         ajax: {
-          url: "{% url 'widgets.api' %}" + window.location.search,
+          url: "{% url 'widgets.api' %}" + window.location.search
         },
         columns: [
           {data: "title",

--- a/grantnav/frontend/templates/components/results-title.html
+++ b/grantnav/frontend/templates/components/results-title.html
@@ -8,7 +8,7 @@
 
     <div class="radio-buttons__group">
         <input class="screen-reader-only" type="radio" id="card-view" name="results-switcher" value="card" checked>
-        <label class="radio-buttons__button" for="card-view">Card view</label>
+        <label class="radio-buttons__button" for="card-view">Classic view</label>
     </div>
 
     <div class="radio-buttons__group">


### PR DESCRIPTION
## Summary
+ Remove "Search all fields" search bar in table view
+ Rename "Card view" to "Classic view"

Related issue: https://github.com/ThreeSixtyGiving/grantnav/issues/875

## Verify
1. Make a search in GrantNav
2. In the results, ensure there are two buttons that read "Classic view" and "Table view"
3. In table view, ensure there is no search field above the table of results