### PR TITLE
insights: Make the button more responsive

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -3,6 +3,12 @@
   align-items: center;
   display: flex; }
 
+.graph-container {
+  width: 80%;
+  height: 80%;
+  margin-left: auto;
+  margin-right: auto; }
+
 @media print {
   *,
   *:before,
@@ -405,6 +411,9 @@ template, [hidden] {
   overflow: hidden;
   white-space: nowrap; }
 
+.margin-top\:0 {
+  margin-top: 0 !important; }
+
 .margin-top\:05 {
   margin-top: .5rem !important; }
 
@@ -548,6 +557,12 @@ template, [hidden] {
 
 .padding-bottom\:5 {
   padding-bottom: 5rem  !important; }
+
+.justify-content-end {
+  justify-content: end; }
+
+.white-wash {
+  background-color: white !important; }
 
 :root {
   --gray-05-hsl: 0, 0%, 95%;
@@ -5446,6 +5461,16 @@ a.base-card:hover:before {
   @media (min-width: 60em) {
     .grantnav-search__content {
       padding-top: 24px; } }
+  .grantnav-search__content--insights-large {
+    display: none; }
+    @media (min-width: 85em) {
+      .grantnav-search__content--insights-large {
+        display: block; } }
+  .grantnav-search__content--insights-small {
+    display: block; }
+    @media (min-width: 85em) {
+      .grantnav-search__content--insights-small {
+        display: none; } }
   .grantnav-search__content--filters {
     display: flex;
     justify-content: space-between;

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -39,8 +39,11 @@
             {% include 'components/dropdown-filter.html' with required=True options=dropdownFilterOptions %}
 
             {% if results.hits.total.value <= 10000 %}
-              <a href="https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org{% url 'search.json' %}%3F{{ query_string|urlencode }}" title="Download search results into 360Insights data visualiser" target="_blank">
-                <button class="button button--large button--teal-dark bold">Visualise your search results in 360Insights</button>
+              <a class="grantnav-search__content--insights-large button button--large button--teal-dark bold margin-left:4 margin-right:2" href="https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org{% url 'search.json' %}%3F{{ query_string|urlencode }}" title="Download search results into 360Insights data visualiser" target="_blank">
+                Visualise your search results in 360Insights
+              </a>
+              <a class="grantnav-search__content--insights-small button button--large button--teal-dark bold margin-left:4 margin-right:4" href="https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org{% url 'search.json' %}%3F{{ query_string|urlencode }}" title="Download search results into 360Insights data visualiser" target="_blank">
+                Visualise in 360Insights
               </a>
             {% endif %}
 


### PR DESCRIPTION
#852 

This makes the insights link more responsive, by adding padding so that elements don't overlap and reducing the copy below a certain breakpoint.

We could flex-wrap the elements in the content-filters onto different rows as an alternative.

## Wide
![Screenshot from 2022-10-28 15-42-27](https://user-images.githubusercontent.com/517804/198653946-f6725130-317f-47a2-a2bf-8060dd74d078.png)

## Narrow
![Screenshot from 2022-10-28 15-42-14](https://user-images.githubusercontent.com/517804/198653961-c4a24cf6-d031-4486-b26b-f494488418d7.png)

## Possible (unrefined) wrap options as an alternative
![Screenshot from 2022-10-28 15-45-06](https://user-images.githubusercontent.com/517804/198655577-17847d9d-0e90-4190-8d9d-a32bb1f701c0.png)
