### PR TITLE
docs: Fix page hierarchy for Organisations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ To learn more about locations in GrantNav, see [Locations](locations)
    understanding_results
    search_bar
    locations
-   organizations
+   organisations
    export
    data
    developers

--- a/docs/organisations.md
+++ b/docs/organisations.md
@@ -7,17 +7,17 @@ Organisations in GrantNav
 
 GrantNav provides a view of all the grants known to be associated with a single organisation. Because one organisation can have lots of different variations of their name (“R S P B”, “Royal Society for the Protection of Birds”, “The RSPB”, and so on), and different organisations can have the same or similar names, GrantNav uses the organisation identifiers (Org IDs) provided by publishers in the 360Giving Data Standard fields Recipient Org:Identifier and Funding Org:Identifier to distinguish between different organisations, and decide what counts as a single organisation.
 
-Using Org IDs in the published 360Giving data, GrantNav attempts to group all the grants associated with a single organisation into a single view, however there are circumstances when that isn’t possible. This means that when exploring organisations in GrantNav, there may be more than one record for the same organisation. 
+Using Org IDs in the published 360Giving data, GrantNav attempts to group all the grants associated with a single organisation into a single view, however there are circumstances when that isn’t possible. This means that when exploring organisations in GrantNav, there may be more than one record for the same organisation.
 
 The following guidance explains further how organisations are identified in 360Giving data and how GrantNav handles this information, explaining why you might see multiple records for the same organisation.
 
-# About organisation identifiers in 360Giving data
+## About organisation identifiers in 360Giving data
 
 In 360Giving data there are two parts to an Org ID:
 - **A list code**: a prefix that describes the list the identifier is taken from.
 - **An identifier** taken from that list.
 
-## For example
+### For example
 
 A charity registered in England and Wales with the Charity Commission of England and Wales, with the charity number ‘1164883’ will use a list code prefix of GB-CHC.
 This gives an unique Org ID of GB-CHC-1164883.
@@ -34,11 +34,11 @@ When there is no official registration number available for an organisation, the
 
 In these cases, GrantNav is not able to group the grants published by different funders together and each different Org ID starting 360G will have a single view. This means a single organisation could have multiple pages on GrantNav.
 
-# About organisation names in 360Giving data
+## About organisation names in 360Giving data
 
 In order to provide a consistent experience, and because one organisation can have lots of different variations of their name, GrantNav uses the names taken from official sources, such as the UK charity and company registers for organisation page titles and filters. When an organisation is a publisher of 360Giving data the name will be taken from the 360Giving Data Registry instead. All versions of an organisation’s name, used in the data and taken from official sources, are displayed on the organisation page.
 
-# Organisation roles in GrantNav
+## Organisation roles in GrantNav
 
 An organisation can appear in GrantNav as a Funder, a Publisher, or a Recipient or any combination of those roles.
 - An organisation is a **Funder** when their details appear in 360Giving data in the Funding Org:Name and Funding Org:Identifier fields.


### PR DESCRIPTION
* Switch to UK spelling of "organizations" so that it picks up the correct .md file
* Make the headings on the organisations page sub headings of the main page to avoid them all appearing in the menu