### PR TITLE
grantnav: prometheus: Fix grant totals count

### DIFF
--- a/grantnav/frontend/tests.py
+++ b/grantnav/frontend/tests.py
@@ -46,6 +46,10 @@ def test_home(provenance_dataload, client, expected_text):
     assert "grant-making" not in str(response.content)
 
 
+def test_prometheus(provenance_dataload, client):
+    assert "total_grants 1254.0" in str(client.get("/prometheus/metrics").content)
+
+
 def test_search(provenance_dataload, client):
     initial_response = client.get('/search?text_query=gardens+AND+fundingOrganization.id:GB-CHC-1156077')
     assert initial_response.status_code == 302

--- a/grantnav/prometheus/views.py
+++ b/grantnav/prometheus/views.py
@@ -43,7 +43,7 @@ class ServiceMetrics(View):
     def _total_grants(self):
         results = totals_query()
 
-        TOTAL_GRANTS.set(results['hits']['total']['value'])
+        TOTAL_GRANTS.set(results['grants']['value'])
 
     def get(self, *args, **kwargs):
         # Update gauges


### PR DESCRIPTION
Now that we have multiple datatypes we need to select grant data as the type of total we're looking for here.

Add test to test for this regression in the future

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/924