### PR TITLE
widgets: add sort dropdown to settings

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -5444,6 +5444,7 @@ a.base-card:hover:before {
       display: none; } }
 
 .grantnav-search__content {
+  overflow-x: auto;
   padding-top: 0px;
   width: 100%; }
   @media (min-width: 60em) {

--- a/grantnav/frontend/templates/components/dropdown-filter.html
+++ b/grantnav/frontend/templates/components/dropdown-filter.html
@@ -1,7 +1,11 @@
 {% load get_current_sort from frontend %}
 <form id="sort-form" class="form-inline">
   <div class="dropdown-filter">
+    {% if title %}
+    <label class="dropdown-filter__label" for="results-sort-dropdown">{{ title }}</label>
+    {% else %}
     <label class="dropdown-filter__label" for="results-sort-dropdown">Sort By:</label>
+    {% endif %}
       <select id="sort_options" name="sort" class="form-control" onchange="sort_changed(this.value)">
       {% with current_sort=query|get_current_sort %}
         {% for option in options %}

--- a/grantnav/frontend/templates/components/grants_table.html
+++ b/grantnav/frontend/templates/components/grants_table.html
@@ -2,20 +2,25 @@
 {% load static %}
     <div class="section">
         <div class="grantnav-datatable__content--filters {% if widget %}margin-top:0{% endif %}">
-        {% if not widget %}
             {% include 'components/dropdown-filter.html' with required=True options=dropdownFilterOptions %}
-            <div class="export-wrapper">
-                <div class="export-label">Export table data:</div>
-                <div class="export-button">
-                    {% include 'components/export-data-button--csv.html' with data_function='search.csv' query=query_string only %}
-                </div>
+            {% if not widget %}
+                {% if results.hits.total.value <= 10000 %}
+                <a class="grantnav-search__content--insights-large button button--large button--teal-dark bold margin-left:4 margin-right:2" href="https://insights.threesixtygiving.org/?url=https://grantnav.threesixtygiving.org{% url 'search.json' %}%3F{{ query_string|urlencode }}" title="Download search results into 360Insights data visualiser" target="_blank">
+                    Visualise your search results in 360Insights
+                </a>
+                {% endif %}
+                <div class="export-wrapper">
+                    <div class="export-label">Export table data:</div>
+                    <div class="export-button">
+                        {% include 'components/export-data-button--csv.html' with data_function='search.csv' query=query_string only %}
+                    </div>
 
-                <div class="export-button">
-                    {% include 'components/export-data-button--json.html' with data_function='search.json' query=query_string only %}
+                    <div class="export-button">
+                        {% include 'components/export-data-button--json.html' with data_function='search.json' query=query_string only %}
+                    </div>
                 </div>
-            </div>
-        {% else %}
-        {% endif %}
+            {% else %}
+            {% endif %}
         </div>
 
         <div class="table--zebra">

--- a/grantnav/frontend/templates/components/grants_table.html
+++ b/grantnav/frontend/templates/components/grants_table.html
@@ -1,37 +1,37 @@
 {% load frontend %}
 {% load static %}
     <div class="section">
-      <div class="grantnav-datatable__content--filters {% if widget %}margin-top:0{% endif %}">
-        {% include 'components/dropdown-filter.html' with required=True options=dropdownFilterOptions %}
+        <div class="grantnav-datatable__content--filters {% if widget %}margin-top:0{% endif %}">
         {% if not widget %}
-          <div class="export-wrapper">
-            <div class="export-label">Export table data:</div>
-              <div class="export-button">
-                {% include 'components/export-data-button--csv.html' with data_function='search.csv' query=query_string only %}
-              </div>
+            {% include 'components/dropdown-filter.html' with required=True options=dropdownFilterOptions %}
+            <div class="export-wrapper">
+                <div class="export-label">Export table data:</div>
+                <div class="export-button">
+                    {% include 'components/export-data-button--csv.html' with data_function='search.csv' query=query_string only %}
+                </div>
 
-              <div class="export-button">
-                 {% include 'components/export-data-button--json.html' with data_function='search.json' query=query_string only %}
-              </div>
-         </div>
+                <div class="export-button">
+                    {% include 'components/export-data-button--json.html' with data_function='search.json' query=query_string only %}
+                </div>
+            </div>
         {% else %}
         {% endif %}
-      </div>
+        </div>
 
-      <div class="table--zebra">
-        <table class="table table--zebra table--primary dt-responsive" id="search_grants_datatable" style="width: 100%">
-          <thead>
-            <tr>
-              <th>Title</th>
-              <th>Amount</th>
-              <th>Date</th>
-              <th>Funder</th>
-              <th>Recipient</th>
-              <th>Description</th>
-            </tr>
-          </thead>
-        </table>
-      </div>
+        <div class="table--zebra">
+            <table class="table table--zebra table--primary dt-responsive" id="search_grants_datatable" style="width: 100%">
+                <thead>
+                    <tr>
+                        <th>Title</th>
+                        <th>Amount</th>
+                        <th>Date</th>
+                        <th>Funder</th>
+                        <th>Recipient</th>
+                        <th>Description</th>
+                    </tr>
+                </thead>
+            </table>
+        </div>
     </div>
 {% block models %} {% include 'currency_stats_modal.html' %}
 {% endblock %}

--- a/grantnav/frontend/templates/search_widgets.html
+++ b/grantnav/frontend/templates/search_widgets.html
@@ -86,7 +86,7 @@
                     <option value="date_graph">Date awarded graph</option>
                   </select>
                 </div>
-                {% include 'components/dropdown-filter.html' with required=True options=dropdownFilterOptions %}
+                {% include 'components/dropdown-filter.html' with title="Default Sort Order:" required=True options=dropdownFilterOptions %}
                 <div class="dropdown-filter flex-centre">
                   <label class="dropdown-filter__label" for="select-views">Recency:</label>
                   <select class="dropdown-filter__select" name="views" id="select-recency" onchange="updateRecency()">

--- a/grantnav/frontend/templates/search_widgets.html
+++ b/grantnav/frontend/templates/search_widgets.html
@@ -86,6 +86,7 @@
                     <option value="date_graph">Date awarded graph</option>
                   </select>
                 </div>
+                {% include 'components/dropdown-filter.html' with required=True options=dropdownFilterOptions %}
                 <div class="dropdown-filter flex-centre">
                   <label class="dropdown-filter__label" for="select-views">Recency:</label>
                   <select class="dropdown-filter__select" name="views" id="select-recency" onchange="updateRecency()">


### PR DESCRIPTION
## Summary
+ Add sort dropdown to widget builder settings.
+ Add "Visualise in 360Insights" button to table view

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/923 & part of https://github.com/ThreeSixtyGiving/grantnav/issues/918

## Verify
1. Visit the widget builder
2. Make a search query and select a sort order using the "Sort by" dropdown
3. The page should reload with the selected sort applied, and reflected in the preview
4. Copy code and embed elsewhere to verify the sort order is preserved

and

1. Return to home and perform a search, using filters to limit results to < 10,000
2. "Visualise in 360Insights" button should be visible in both classic and table view