### PR TITLE
tables: manually apply responsivity & pagination

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -5551,7 +5551,7 @@ a.base-card:hover:before {
   margin: 8px; }
 
 .dataTables_info {
-  margin: 8px; }
+  margin: 8px 0 8px 0; }
 
 .input-sm {
   margin-left: 8px; }
@@ -5997,3 +5997,31 @@ select.front_search {
   background-color: #ecf0f1;
   border-color: #ecf0f1;
   color: #000; }
+
+.dt-pager-container {
+  display: flex;
+  justify-content: center; }
+  .dt-pager-container .pager {
+    margin: 64px auto 0 auto;
+    padding: 12px 18px; }
+  .dt-pager-container .dataTables_paginate .ellipsis {
+    padding: 0 12px; }
+  .dt-pager-container .paginate_button {
+    margin: 0 4px;
+    padding: 6px; }
+    .dt-pager-container .paginate_button.current {
+      font-weight: bold; }
+    .dt-pager-container .paginate_button.previous {
+      margin-right: 20px;
+      padding: 0 6px;
+      text-decoration: none; }
+      .dt-pager-container .paginate_button.previous:hover svg {
+        stroke: #DE6E26; }
+    .dt-pager-container .paginate_button.next {
+      margin-left: 20px;
+      padding: 0 6px;
+      text-decoration: none; }
+      .dt-pager-container .paginate_button.next:hover svg {
+        stroke: #DE6E26; }
+    .dt-pager-container .paginate_button.disabled {
+      display: none; }

--- a/grantnav/frontend/templates/components/grants_table.html
+++ b/grantnav/frontend/templates/components/grants_table.html
@@ -27,12 +27,12 @@
             <table class="table table--zebra table--primary dt-responsive" id="search_grants_datatable" style="width: 100%">
                 <thead>
                     <tr>
-                        <th>Title</th>
-                        <th>Amount</th>
-                        <th>Date</th>
-                        <th>Funder</th>
-                        <th>Recipient</th>
-                        <th>Description</th>
+                        <th class="max-desktop">Title</th>
+                        <th class="min-tablet-l">Amount</th>
+                        <th class="min-tablet-l">Date</th>
+                        <th class="min-desktop">Funder</th>
+                        <th class="min-desktop">Recipient</th>
+                        <th class="none">Description</th>
                     </tr>
                 </thead>
             </table>

--- a/grantnav/frontend/templates/components/grants_table_scripts.html
+++ b/grantnav/frontend/templates/components/grants_table_scripts.html
@@ -21,7 +21,7 @@
       $('#search_grants_datatable').DataTable().responsive.recalc();
       $('#search_grants_datatable').DataTable().columns.adjust();
     });
-    
+
     function truncate(string, len) {
         if (string.length > len)
           return string.substring(0,len)+'...';
@@ -71,7 +71,7 @@
         columns: [
           {data: "title",
           render: function (data, type, row) {
-              return '<a href="/grant/' + encodeURIComponent(row.id) + '">' + truncate(data, 40) + '</a>'
+              return '<a href="/grant/' + encodeURIComponent(row.id) + '">' + truncate(data, 40) + '</a>';
           }, orderable: false},
           {data: "amountAwarded", className: "amount", orderable: false},
           {data: "awardDate", orderable: false},
@@ -81,21 +81,21 @@
         ]
     });
 
-    const table = $('#search_grants_datatable').DataTable()
+    const table = $('#search_grants_datatable').DataTable();
     table.on('responsive-display', function ( e, datatable, row, showHide, update ) {
     });
     table.on('draw', function() {
         if (document.getElementById('search_grants_datatable_paginate')) {
-            const previousButton = document.getElementById('search_grants_datatable_previous')
+            const previousButton = document.getElementById('search_grants_datatable_previous');
             if (previousButton !== null) {
-                previousButton.innerHTML = '<svg width="9" height="14" viewBox="0 0 9 14" fill="none" stroke="#2B666A" xmlns="http://www.w3.org/2000/svg">  <path d="M1.60577 6.6709L7.19434 12.5037" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path><path d="M1.60594 6.67081L7.18164 0.932251" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path></svg>'
+                previousButton.innerHTML = '<svg width="9" height="14" viewBox="0 0 9 14" fill="none" stroke="#2B666A" xmlns="http://www.w3.org/2000/svg">  <path d="M1.60577 6.6709L7.19434 12.5037" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path><path d="M1.60594 6.67081L7.18164 0.932251" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path></svg>';
             }
             const nextButton = document.getElementById('search_grants_datatable_next')
             if (nextButton !== null) {
-                nextButton.innerHTML = '<svg width="8" height="14" viewBox="0 0 8 14" fill="none" stroke="#2B666A" xmlns="http://www.w3.org/2000/svg"><path d="M6.54437 6.76514L0.95581 0.93229" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path><path d="M6.54421 6.76522L0.968506 12.5038" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path></svg>'
+                nextButton.innerHTML = '<svg width="8" height="14" viewBox="0 0 8 14" fill="none" stroke="#2B666A" xmlns="http://www.w3.org/2000/svg"><path d="M6.54437 6.76514L0.95581 0.93229" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path><path d="M6.54421 6.76522L0.968506 12.5038" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path></svg>';
             }
         }
-    })
-})
+    });
+});
 
     </script>

--- a/grantnav/frontend/templates/components/grants_table_scripts.html
+++ b/grantnav/frontend/templates/components/grants_table_scripts.html
@@ -82,8 +82,6 @@
     });
 
     const table = $('#search_grants_datatable').DataTable();
-    table.on('responsive-display', function ( e, datatable, row, showHide, update ) {
-    });
     table.on('draw', function() {
         if (document.getElementById('search_grants_datatable_paginate')) {
             const previousButton = document.getElementById('search_grants_datatable_previous');

--- a/grantnav/frontend/templates/components/grants_table_scripts.html
+++ b/grantnav/frontend/templates/components/grants_table_scripts.html
@@ -46,24 +46,22 @@
         case "awardDate asc":
           return [[2, "asc"]]
           break
-        return [[0, "desc"]]
+        default:
+          return [[0, "desc"]]
+          break
       }
     };
 
     jQuery(function($) {
       $('#search_grants_datatable').dataTable({
         serverSide: true,
-        responsive: true,
+        responsive:true,
         searching: false,
         autoWidth: true,
-        scrollY: 400,
-        scroller: true,
+        pagingType: "full_numbers",
+        lengthMenu: [ 25, 50, 75, 100 ],
         order: getSortValue(),
-        dom: "fit",
-        scroller: {
-          displayBuffer: 20,
-          loadingIndicator: true
-        },
+        dom: 'filt<"dt-pager-container"<"pager"p>>',
         language: {
             info: "_START_ to _END_ of _TOTAL_"
         },
@@ -79,8 +77,25 @@
           {data: "awardDate", orderable: false},
           {data: "fundingOrganization.0.name", render: function (data, type, row) {return '<a href="/org/' + row.fundingOrganization[0].id + '">' + truncate(data, 30) + '</a>'}, orderable: false},
           {data: "recipientOrganization.0.name", render: function (data, type, row) {return '<a href="/org/' + row.recipientOrganization[0].id + '">' + truncate(data?data:row.recipientOrganization[0].id, 30) + '</a>'}, orderable: false},
-          {data: "description", orderable: false},
+          {data: "description", orderable: false, responsivePriority: -1},
         ]
-      });
+    });
+
+    const table = $('#search_grants_datatable').DataTable()
+    table.on('responsive-display', function ( e, datatable, row, showHide, update ) {
+    });
+    table.on('draw', function() {
+        if (document.getElementById('search_grants_datatable_paginate')) {
+            const previousButton = document.getElementById('search_grants_datatable_previous')
+            if (previousButton !== null) {
+                previousButton.innerHTML = '<svg width="9" height="14" viewBox="0 0 9 14" fill="none" stroke="#2B666A" xmlns="http://www.w3.org/2000/svg">  <path d="M1.60577 6.6709L7.19434 12.5037" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path><path d="M1.60594 6.67081L7.18164 0.932251" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path></svg>'
+            }
+            const nextButton = document.getElementById('search_grants_datatable_next')
+            if (nextButton !== null) {
+                nextButton.innerHTML = '<svg width="8" height="14" viewBox="0 0 8 14" fill="none" stroke="#2B666A" xmlns="http://www.w3.org/2000/svg"><path d="M6.54437 6.76514L0.95581 0.93229" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path><path d="M6.54421 6.76522L0.968506 12.5038" stroke-width="1.2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"></path></svg>'
+            }
+        }
     })
+})
+
     </script>


### PR DESCRIPTION
## Summary
+ Remove table scrollY
+ Add table pagination
+ Fix broken responsiveness (caused by removing scrollY)
+ Set table height to show 25 results minimum

Relies upon: https://github.com/ThreeSixtyGiving/360-ds/pull/88

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/906

## Verify
1. Make a search; the results should show the following components:
   + Dropdown list at the top of the table showing length of displayed entries, with "Show 25 entries" by default
   + Pagination at the bottom of the table, styled to imitate Design System pager component
2. The "Description" column should be hidden as a child row at any screen width
3. Make the screen narrower; the columns should collapse into the child row until, at tablet/mobile width, only the "Title" column is visible.