### PR TITLE
templates: table widget: Make sure in widget mode to open in new window

### DIFF
--- a/grantnav/frontend/templates/components/grants_table_scripts.html
+++ b/grantnav/frontend/templates/components/grants_table_scripts.html
@@ -15,7 +15,17 @@
 
   {% include 'widgets/grantnav_link_script.html' %}
 
+  <script type="application/json" id="script-settings">
+  {% if widget %}
+    {"linkTarget": "target='_blank'" }
+  {% else %}
+    {"linkTarget": "" }
+  {% endif %}
+  </script>
+
   <script>
+    const settings = JSON.parse($('#script-settings').text());
+
     $(window).resize(function () {
       $('#search_grants_datatable').DataTable().responsive.recalc();
       $('#search_grants_datatable').DataTable().columns.adjust();
@@ -62,18 +72,24 @@ jQuery(function ($) {
           {
             data: 'title',
             render: function (data, type, row) {
-              return '<a href="/grant/' + encodeURIComponent(row.id) + '">' + truncate(data, 40) + '</a>';
+              return `<a href="/grant/${encodeURIComponent(row.id)}" ${settings.linkTarget}>${truncate(data, 40)}</a>`;
             },
             orderable: false
           },
           { data: 'amountAwarded', className: 'amount', orderable: false },
           { data: 'awardDate', orderable: false },
-          { data: 'fundingOrganization.0.name', render: function (data, type, row) { return '<a href="/org/' + row.fundingOrganization[0].id + '">' + truncate(data, 30) + '</a>'; }, orderable: false },
+          {
+            data: 'fundingOrganization.0.name',
+            render: function (data, type, row) {
+              return `<a href="/org/${row.fundingOrganization[0].id}" ${settings.linkTarget}>${truncate(data, 30)}</a>`;
+            },
+            orderable: false
+          },
           {
             data: 'recipientOrganization.0.name',
             render: function (data, type, row) {
               if (row.recipientOrganization) {
-                return '<a href="/org/' + row.recipientOrganization[0].id + '">' + truncate(data || row.recipientOrganization[0].id, 30) + '</a>';
+                return `<a href="/org/${row.recipientOrganization[0].id}" ${settings.linkTarget}>${truncate(data || row.recipientOrganization[0].id, 30)}</a>`;
               } else { return 'Individual'; }
             },
             orderable: false

--- a/grantnav/frontend/templates/widgets/tabular_grants.html
+++ b/grantnav/frontend/templates/widgets/tabular_grants.html
@@ -10,5 +10,5 @@
 {% endblock %}
 
 {% block extra_scripts %}
-  {% include 'components/grants_table_scripts.html' %}
+  {% include 'components/grants_table_scripts.html' with widget=True %}
 {% endblock %}


### PR DESCRIPTION
When we've embedded a table as a widget we want to make sure clicking links to data takes us to Grantnav in a new window.

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/954