### PR TITLE
grantnav frontend/docs: Remove /api/ downloads in favour search export

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -7,7 +7,7 @@ GrantNav provides a rich source of grants data for developers; the JSON download
 
 GrantNav isn't designed to be incorporated into an application, and we don't guarantee API stability or performance, so developers should ensure that they don't rely on GrantNav for time-critical processes. The data's updated once a day, overnight (UK time), so it's not necessary to poll for updates more regularly than that. 
 
-The entire data set can be exported as [JSON](http://grantnav.threesixtygiving.org/api/grants.json) or [CSV](http://grantnav.threesixtygiving.org/api/grants.csv)
+The entire data set can be exported as [JSON](http://grantnav.threesixtygiving.org/search.json) or [CSV](http://grantnav.threesixtygiving.org/search.csv)
 
 The full JSON download is several hundred MB, and growing slowly as more organisations start to publish, and existing publishers add to their published data.
 

--- a/docs/export.md
+++ b/docs/export.md
@@ -16,11 +16,11 @@ The JSON files of grants contain all of the data supplied in the original data (
 
 The CSV files of grants contain all of the required fields from the 360Giving standard, the most commonly-used optional fields from the standard, plus some commonly-used fields from the data added by the 360Giving pipeline. Columns may be entirely blank if no grant in your download uses a particular field; individual rows may have blank fields if the source data doesn't contain that field. 
 
-Grants export files use the [360Giving Standard](https://standard.threesixtygiving.org/en/latest/); refer to the standard website to understand the meaning and contents of the fields. 
+Grants export files use the [360Giving Standard](https://standard.threesixtygiving.org/en/latest/); refer to the standard website to understand the meaning and contents of the fields.
 
 Note that export files can be very large - in particular the whole dataset is several hundred MB, and large search results can be a similar size. Refining your search or splitting up your export can help, but be aware of the constraints around [refining search results](refining-results)
 
-The entire data set can be exported as [JSON](http://grantnav.threesixtygiving.org/api/grants.json) or [CSV](http://grantnav.threesixtygiving.org/api/grants.csv)
+The entire data set can be exported as [JSON](http://grantnav.threesixtygiving.org/search.json) or [CSV](http://grantnav.threesixtygiving.org/search.csv)
 
 
 ```eval_rst

--- a/grantnav/frontend/urls.py
+++ b/grantnav/frontend/urls.py
@@ -38,8 +38,6 @@ urlpatterns = [
     url(r'^datasets/$', views.datasets, name='datasets'),
     url(r'^terms', TemplateView.as_view(template_name='terms.html'), name='terms'),
     url(r'^about', TemplateView.as_view(template_name='about.html'), name='about'),
-    url(r'^api/grants.json', views.api_grants, name='api.grants.json'),
-    url(r'^api/grants.csv', views.api_grants, name='api.grants.csv'),
     # Redirects
     url(r'^publisher/(.*)$', views.publisher, name='publisher'),
     url(r'^recipient/(.*)$', views.recipient, name='recipient'),

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -1444,12 +1444,3 @@ def datasets(request):
         'publishers': provenance.by_publisher.values(),
         'datasets': provenance.datasets,
     })
-
-
-def api_grants(request):
-    [result_format, results_size] = get_request_type_and_size(request)
-    query = {"query": {"match_all": {}}}
-    if result_format == "csv":
-        return grants_csv_paged(query)
-    elif result_format == "json":
-        return grants_json_paged(query)


### PR DESCRIPTION
De-duplicate this functionality and remove url and view Update internal docs to reflect change.

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/955