### PR TITLE
frontend: widgets: Update CTA copy

### DIFF
--- a/grantnav/frontend/templates/widgets/widgets_header.html
+++ b/grantnav/frontend/templates/widgets/widgets_header.html
@@ -8,7 +8,7 @@
     <strong>{{ title }}</strong>
   </div>
   <div class="nav-bar__nav-menu justify-content-end white-wash">
-    <span>To explore this dataset in more detail, open in
+    <span>To explore this dataset in more detail, or filter the search results, open in
     </span>
     <a class="grantnav-link" href="about:blank" target="_blank">
       Grantnav


### PR DESCRIPTION
## Summary
+ Update copy

Fixes https://github.com/ThreeSixtyGiving/grantnav/issues/964

## Verify
1. Open a widget or the widget builder
2. Verify the copy reads, "To explore this dataset in more detail, or filter the search results, open in Grantnav".