### PR TITLE
ml/responsive-org-tables

### DIFF
--- a/grantnav/frontend/static/css/main.css
+++ b/grantnav/frontend/static/css/main.css
@@ -1554,7 +1554,6 @@ p {
   --scale: 127;
   --bar-bg-color: hsla(var(--yellow-hsl), 1); }
   .bar-chart__item {
-    --value: 0;
     display: flex;
     padding-bottom: 8px; }
   .bar-chart__bar {
@@ -1570,8 +1569,7 @@ p {
       background-color: var(--bar-bg-color);
       width: var(--width); }
     .bar-chart__bar > span:after {
-      counter-reset: value var(--value);
-      content: counter(value);
+      content: attr(data-val);
       position: absolute;
       left: calc(100% + 8px); }
   .bar-chart__label {
@@ -3989,7 +3987,7 @@ a.base-card:hover:before {
   .media-card__content_no_image {
     justify-content: center;
     padding: 20px;
-    width: 100%; }
+    width: 100vw; }
   .media-card__image-wrapper {
     width: 30%;
     max-width: 320px;

--- a/grantnav/frontend/templates/components/grants_table.html
+++ b/grantnav/frontend/templates/components/grants_table.html
@@ -27,7 +27,7 @@
             <table class="table table--zebra table--primary dt-responsive" id="search_grants_datatable" style="width: 100%">
                 <thead>
                     <tr>
-                        <th class="max-desktop">Title</th>
+                        <th class="all">Title</th>
                         <th class="min-tablet-l">Amount</th>
                         <th class="min-tablet-l">Date</th>
                         <th class="min-desktop">Funder</th>

--- a/grantnav/frontend/templates/components/org-page-funder.html
+++ b/grantnav/frontend/templates/components/org-page-funder.html
@@ -47,23 +47,25 @@
 
     <p>{{org_names.0}} makes grants in {{funder.stats_by_currency|length}} currencies.</p>
 
-    <table class="table table--zebra" style="width: 100%">
+    <table class="table table--zebra dt-responsive generic_datatables" style="width: 100%">
         <thead>
-            <th>Currency</th>
-            <th>Grants</th>
-            <th>Total Amount</th>
-            <th>Greatest Amount</th>
-            <th>Smallest Amount</th>
+          <tr>
+            <th class="all">Currency</th>
+            <th class="min-tablet-p">Grants</th>
+            <th class="amount min-tablet-p">Total Amount</th>
+            <th class="amount min-tablet-l">Greatest Amount</th>
+            <th class="amount min-tablet-l">Smallest Amount</th>
+          </tr>
         </thead>
         <tbody>
         {% for stat in funder.stats_by_currency %}
-        <tr>
+          <tr>
             <td class="table__lead-cell">{{stat.currency}}</td>
             <td>{{stat.grants | get_amount }}</td>
             <td>{{stat.currency | currency_symbol}}{{stat.total | get_amount}}</td>
             <td>{{stat.currency | currency_symbol}}{{stat.max | get_amount}}</td>
             <td>{{stat.currency | currency_symbol}}{{stat.min | get_amount}}</td>
-        </tr>
+          </tr>
         {% endfor %}
         </tbody>
     </table>
@@ -101,14 +103,14 @@
         </div>
         </div>
         <div class="table table--zebra">
-        <table class="table table--zebra table--small dt-responsive full-width" id="recipients_datatable">
+        <table class="table table--zebra table--small dt-responsive" id="recipients_datatable" style="width: 100%">
             <thead>
             <tr>
-                <th>Recipient</th>
-                <th>Grants</th>
-                <th class="amount">Total</th>
-                <th class="amount">Largest</th>
-                <th class="amount">Smallest</th>
+                <th class="all">Recipient</th>
+                <th class="min-tablet-p">Grants</th>
+                <th class="amount min-tablet-p">Total</th>
+                <th class="amount min-tablet-l">Largest</th>
+                <th class="amount min-tablet-l">Smallest</th>
             </tr>
             </thead>
         </table>

--- a/grantnav/frontend/templates/components/org-page-publisher.html
+++ b/grantnav/frontend/templates/components/org-page-publisher.html
@@ -22,19 +22,19 @@
 
         <h4>Datasets</h4>
         <p>Here is an overview of grants published by {{publisher.name}}.</p>
-        <table class="table table--primary table--small dt-responsive">
+        <table class="table table--zebra table--small dt-responsive generic_datatables" style="width: 100%">
         <thead>
             <tr>
-            <th>Dataset (download link)</th>
-            <th>Retrieved for use in GrantNav</th>
-            <th>License</th>
-            <th>Funders covered</th>
+            <th class="all">Dataset (download link)</th>
+            <th class="min-tablet-p">Retrieved for use in GrantNav</th>
+            <th class="min-tablet-l">License</th>
+            <th class="min-tablet-l">Funders covered</th>
             </tr>
         </thead>
         <tbody>
             {% for dataset in publisher.datasets %}
             <tr>
-            <td><a href="{{ dataset.distribution.0.downloadURL }}">{{ dataset.title }}</a></td>
+            <td class="table__lead-cell"><a href="{{ dataset.distribution.0.downloadURL }}">{{ dataset.title }}</a></td>
             <td>{{ dataset.datagetter_metadata.datetime_downloaded }}</td>
             <td><a href="{{ dataset.license }}">{{ dataset.license }}</a></td>
             <td>

--- a/grantnav/frontend/templates/components/org-page-recipient.html
+++ b/grantnav/frontend/templates/components/org-page-recipient.html
@@ -44,13 +44,15 @@
 
     <p>{{org_names.0}} received grants in {{recipient.stats_by_currency|length}} currencies.</p>
 
-    <table class="table table--zebra" style="width: 100%">
+    <table class="table table--zebra dt-responsive generic_datatables" style="width: 100%">
         <thead>
-            <th>Currency</th>
-            <th>Grants</th>
-            <th>Total Amount</th>
-            <th>Greatest Amount</th>
-            <th>Smallest Amount</th>
+          <tr>
+            <th class="all">Currency</th>
+            <th class="min-tablet-p">Grants</th>
+            <th class="amount min-tablet-p">Total Amount</th>
+            <th class="amount min-tablet-l">Greatest Amount</th>
+            <th class="amount min-tablet-l">Smallest Amount</th>
+          </tr>
         </thead>
         <tbody>
         {% for stat in recipient.stats_by_currency %}
@@ -75,24 +77,25 @@
     <p>This table shows the funders who have made grants to {{org_names.0}}</p>
 
     {% for currency, funders in recipient_funders.items %}
-        <h4>Funders <small>({{currency}})</small></h4>
-        <table class="table table--primary table--primary table--small dt-responsive">
+    <h4>Funders <small>({{currency}})</small></h4>
+        <table class="table table--zebra table--small dt-responsive generic_datatables" style="width: 100%">
             <thead>
                 <tr>
-                <th>Funder</th>
-                <th>Grants</th>
-                <th>Total</th>
-                <th>Smallest</th>
-                <th>Largest</th>
+                  <th class="all">Funder</th>
+                  <th class="min-tablet-p">Grants</th>
+                  <th class="amount min-tablet-p">Total</th>
+                  <th class="amount min-tablet-l">Largest</th>
+                  <th class="amount min-tablet-l">Smallest</th>
+                </tr>
             </thead>
             <tbody>
                 {% for funder in funders %}
                 <tr>
-                <td><a href="{% url 'org' funder.org_id %}">{{ funder.name }}</a></td>
-                <td>{{ funder.count | get_amount }}</td>
-                <td>{{currency | currency_symbol}}{{ funder.sum | get_amount }}</td>
-                <td>{{currency | currency_symbol}}{{ funder.min | get_amount }}</td>
-                <td>{{currency | currency_symbol}}{{ funder.max | get_amount }}</td>
+                  <td><a href="{% url 'org' funder.org_id %}">{{ funder.name }}</a></td>
+                  <td>{{ funder.count | get_amount }}</td>
+                  <td>{{currency | currency_symbol}}{{ funder.sum | get_amount }}</td>
+                  <td>{{currency | currency_symbol}}{{ funder.max | get_amount }}</td>
+                  <td>{{currency | currency_symbol}}{{ funder.min | get_amount }}</td>
                 </tr>
                 {% endfor %}
             </tbody>

--- a/grantnav/frontend/templates/org.html
+++ b/grantnav/frontend/templates/org.html
@@ -127,48 +127,63 @@
 {{ funder.org_ids|json_script:"orgIDs" }}
 
 <script>
-    function truncate (string, len) {
-      if (string.length > len) { return string.substring(0, len) + '...'; } else { return string; }
-    }
+
+  function truncate (string, len) {
+    if (string.length > len) { return string.substring(0, len) + '...'; } else { return string; }
+  }
 
 jQuery(function ($) {
-      $('#recipients_datatable').dataTable({
-        serverSide: true,
-        responsive: true,
-        searching: true,
-        autoWidth: false,
-        scrollY: 400,
-        dom: 'fit',
-        scroller: {
-          displayBuffer: 15,
-          loadingIndicator: true
-        },
-        order: [[2, 'desc']],
-        language: {
-          info: '_START_ to _END_ of _TOTAL_',
-          search: 'Search Recipients'
-        },
-        ajax: {
-          url: "{% url 'funder_recipients_datatables' %}",
-          data: function (d) {
-            d.funder_id = document.getElementById('orgIDs').textContent;
-            d.currency = '{{funder.stats_by_currency.0.currency|escapejs}}';
-          }
-        },
-        columns: [
-          {
-            data: 'org_name',
-            width: '10px',
-            render: function (data, type, row) {
-              return '<a href="/org/' + encodeURIComponent(row.org_id) + '">' + truncate(data, 20) + '</a>';
-            }
-          },
-          { data: 'count' },
-          { data: 'sum', className: 'amount' },
-          { data: 'max', className: 'amount' },
-          { data: 'min', className: 'amount' }
-        ]
-      });
+  $('.generic_datatables').dataTable({
+    responsive: {
+      breakpoints: [
+        { name: 'mobile-l',   width: 575 },
+      ]
+    },
+  });
+});
+
+jQuery(function ($) {
+  $('#recipients_datatable').dataTable({
+    serverSide: true,
+    responsive: {
+      breakpoints: [
+        { name: 'mobile-l',   width: 575 },
+      ]
+    },
+    searching: true,
+    autoWidth: true,
+    scrollY: 400,
+    dom: 'fit',
+    scroller: {
+      displayBuffer: 15,
+      loadingIndicator: true
+    },
+    order: [[2, 'desc']],
+    language: {
+      info: '_START_ to _END_ of _TOTAL_',
+      search: 'Search Recipients'
+    },
+    ajax: {
+      url: "{% url 'funder_recipients_datatables' %}",
+      data: function (d) {
+        d.funder_id = document.getElementById('orgIDs').textContent;
+        d.currency = '{{funder.stats_by_currency.0.currency|escapejs}}';
+      }
+    },
+    columns: [
+      {
+        data: 'org_name',
+        width: '10px',
+        render: function (data, type, row) {
+          return '<a href="/org/' + encodeURIComponent(row.org_id) + '">' + truncate(data, 20) + '</a>';
+        }
+      },
+      { data: 'count'},
+      { data: 'sum' },
+      { data: 'max' },
+      { data: 'min' }
+    ]
+  });
 });
 </script>
 {% endblock %}

--- a/grantnav/frontend/templates/org.html
+++ b/grantnav/frontend/templates/org.html
@@ -127,18 +127,17 @@
 {{ funder.org_ids|json_script:"orgIDs" }}
 
 <script>
-
-  function truncate (string, len) {
-    if (string.length > len) { return string.substring(0, len) + '...'; } else { return string; }
-  }
+function truncate (string, len) {
+  if (string.length > len) { return string.substring(0, len) + '...'; } else { return string; }
+}
 
 jQuery(function ($) {
   $('.generic_datatables').dataTable({
     responsive: {
       breakpoints: [
-        { name: 'mobile-l',   width: 575 },
+        { name: 'mobile-l', width: 575 }
       ]
-    },
+    }
   });
 });
 
@@ -147,7 +146,7 @@ jQuery(function ($) {
     serverSide: true,
     responsive: {
       breakpoints: [
-        { name: 'mobile-l',   width: 575 },
+        { name: 'mobile-l', width: 575 }
       ]
     },
     searching: true,
@@ -178,7 +177,7 @@ jQuery(function ($) {
           return '<a href="/org/' + encodeURIComponent(row.org_id) + '">' + truncate(data, 20) + '</a>';
         }
       },
-      { data: 'count'},
+      { data: 'count' },
       { data: 'sum' },
       { data: 'max' },
       { data: 'min' }


### PR DESCRIPTION
## Summary
+ Initialise datatables on org pages correctly
+ Apply custom `mobile-l` breakpoint
+ Apply breakpoint classes to all org page table columns

Fixes https://github.com/ThreeSixtyGiving/grantnav/issues/913

## Verify
1. Visit a selection of org pages; try to find ones with tables in both the funders and recipients sections
2. Make the viewport narrower (either by using a mobile device, using browser tools or by adjusting the browser window itself)
3. All tables on org pages should now be fully responsive; columns should collapse into child rows, expandable with a chevron button.