### PR TITLE
templates: grant: Add feature to show details of grant to individual

### DIFF
--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -22,7 +22,7 @@
       </h1>
     </div>
 
-    {% if grant.source.fundingOrganization.0.id and grant.source.recipientOrganization.0.id %}
+    {% if grant.source.fundingOrganization.0.id %}
     <div class="spacer-4">
       <div class="grant-info-highlight grid grid--three-columns">
         <div class="grant-info-highlight__funder">
@@ -41,13 +41,24 @@
 
           <div class="grant-info-highlight__data--date"><time datetime="{{ grant.source.awardDate }}">{{grant.source.awardDate|get_date}}</time></div>
         </div>
-
+       {% if grant.source.recipientOrganization.0.id %}
         <div class="grant-info-highlight__recipient">
           <div class="grant-info-highlight__label">Recipient Organization</div>
           <div>
             <p><a href="{% url 'org' grant.source.recipientOrganization.0.id %}"> {{ grant.source.recipientOrganization.0|get_name|truncatechars:50 }} <small>({{ grant.source.recipientOrganization.0.id|truncatechars:20}}) </small> </a>
           </div>
         </div>
+        {% endif %}
+
+       {% if grant.source.recipientIndividual.id %}
+        <div class="grant-info-highlight__recipient">
+          <div class="grant-info-highlight__label">Recipient Individual</div>
+          <div>
+            <p><a href="{% url 'search' %}?query=recipientIndividual.id:{{grant.source.recipientIndividual.id}}" > {{grant.source.recipientIndividual.name}} <small>({{grant.source.recipientIndividual.id}})</small> </a>
+          </div>
+        </div>
+        {% endif %}
+
       </div>
     </div>
     {% endif %}


### PR DESCRIPTION
Add a grant details page for individuals based on existing design:

![image](https://github.com/ThreeSixtyGiving/grantnav/assets/493697/aeec74e5-6c2b-443a-8c98-52d558d70fe9)


The link when the grant is to a recipient organisation normally goes to the org page. The best idea I had for where the link could go to was link it to a field search `recipientIndividual.id:360G-id-2344-example`. Real example https://grantnav.threesixtygiving.org/search?query=recipientIndividual.id%3A360G-BarnwoodTrust-IND-0001_2022-06&default_field=%2A&sort=_score+desc&recipientTSGType=Individual 