### PR TITLE
views: get_recipient_funders Change funders limit to total funders

### DIFF
--- a/grantnav/frontend/templates/components/org-page-recipient.html
+++ b/grantnav/frontend/templates/components/org-page-recipient.html
@@ -72,7 +72,6 @@
     <a href="{% url 'search' %}?{{recipient.grant_search_parameters}}" class="button pull-right" title="Explore all the grants {{org_names.0}} has received">Explore Grants</a>
 
     <p>This table shows the funders who have made grants to {{org_names.0}}</p>
-
     {% for currency, funders in recipient_funders.items %}
     <h4>Funders <small>({{currency}})</small></h4>
         <table class="table table--zebra table--small dt-responsive generic_datatables" style="width: 100%">

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -986,6 +986,10 @@ def get_funder_info(funder_org_ids):
 
 
 def get_recipient_funders(recipient_org_ids):
+
+    # Dynamically limit the required size to the total number of possible funders
+    max_funders = get_results({"query": {"match_all": {}}}, data_type='funder')['hits']['total']["value"]
+
     query = {
         "query": {
             "bool": {
@@ -999,7 +1003,7 @@ def get_recipient_funders(recipient_org_ids):
                 "aggs": {
                     "funders": {
                         "terms": {
-                            "field": "fundingOrganization.id_and_name", "size": 10
+                            "field": "fundingOrganization.id_and_name", "size": max_funders
                         },
                         "aggs": {
                             "funder_stats": {


### PR DESCRIPTION
As we need to specify a size of results set this to the total number of funders in the system (currently 258).

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/983