### PR TITLE
settings: Namespace the static directory

### DIFF
--- a/grantnav/settings.py
+++ b/grantnav/settings.py
@@ -168,7 +168,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = '/grantnav_static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # Logging


### PR DESCRIPTION
This avoids any potential namespace clashes on servers which have other applications running on them as this can be an URL setup in the global webserver name space.