### PR TITLE
Add Funding Type:Title to download

### DIFF
--- a/grantnav/csv_layout.py
+++ b/grantnav/csv_layout.py
@@ -36,6 +36,7 @@ grants_csv = OrderedDict([
     ("Grant Programme:Code", "result.grantProgramme.0.code"),
     ("Grant Programme:Title", "result.grantProgramme.0.title"),
     ("Grant Programme:URL", "result.grantProgramme.0.url"),
+    ("Funding Type:Title", "result.fundingType.0.title"),
     ("Beneficiary Location:0:Name", "result.beneficiaryLocation.0.name"),
     ("Beneficiary Location:0:Country Code", "result.beneficiaryLocation.0.countryCode"),
     ("Beneficiary Location:0:Geographic Code", "result.beneficiaryLocation.0.geoCode"),


### PR DESCRIPTION
This PR implements feature requested in issue https://github.com/ThreeSixtyGiving/grantnav/issues/928 to add the Funding Type field to GrantNav CSV downloads https://standard.threesixtygiving.org/en/latest/technical/reference/#funding-type

I found the path `fundingType.0.title` with reference to:
* The JSON schema says `fundingType` is an Array of Classification https://standard.threesixtygiving.org/en/latest/_static/docson/index.html#../360-giving-schema.json
* the paths listed in this "360Giving Data Standard Schema" table https://standard.threesixtygiving.org/en/latest/technical/reference/#giving-data-standard-schema

Closes #928

Only thing I'm not sure about, should the CSV field be just `Funding Type` instead of `Funding Type:Title`?