### PR TITLE
Update Filter reference table and fix internal references

### DIFF
--- a/docs/refining_results.md
+++ b/docs/refining_results.md
@@ -43,8 +43,8 @@ The numbers in brackets next to the values show the number of grants in the sear
     - Recipient Org:Name
     - See also: :doc:`./organisations`
   * - Funding Organisation Type
-    - tbc
-    - Values are taken from tbc 
+    - This filter is derived from 360Giving data by GrantNav
+    - Derived from organisation identifiers
   * - Grant Programme Title
     - Grant Programme Title
     - Values are taken from the data

--- a/docs/refining_results.md
+++ b/docs/refining_results.md
@@ -27,21 +27,33 @@ The numbers in brackets next to the values show the number of grants in the sear
   * - Amount Awarded (GBP)
     - Amount Awarded
     - Using this filter will exclude all non-GBP grants from the search results
-  * - Award Year
-    - The year (YYYY) component of date from Award Date field
-    - This is calendar year, not fiscal/financial year. See <a href="#ranges">Ranges</a> for how to search between specific dates.
+  * - Award Date
+    - Award Date
+    - The year values are calendar year, not fiscal/financial year, or a range can be selected in the From/To months. See `Ranges <search_bar#searching-ranges>` for how to search between specific dates.
   * - Recipient Region
     - This filter is derived from 360Giving data by GrantNav
-    - See also: [GrantNav and location data](locations)
+    - See also: `GrantNav and location data <locations>`
   * - Recipient District
     - This filter is derived from 360Giving data by GrantNav
-    - See also: [GrantNav and location data](locations)
+    - See also: `GrantNav and location data <locations>`
   * - Funding Organisations
     - Funding Org:Name
     - Values are taken from the data and will change if the funder name changes.
   * - Recipient Organisations
     - Recipient Org:Name
-    - See also: [Organisations in GrantNav](organisations)
+    - See also: `Organisations in GrantNav <organisations>`
+  * - Funding Organisation Type
+    - tbc
+    - Values are taken from tbc 
+  * - Grant Programme Title
+    - Grant Programme Title
+    - Values are taken from the data
+  * - Type of Recipient
+    - Recipient Org:Name or Recipient Ind:Name
+    - Derived from whether the Recipient Organisation or Individual fields are used in the data
+  * - Grant Type
+    - For Regrant
+    - Derived from whether the For Regrant field was used or not in the data
 ```
 
   

--- a/docs/refining_results.md
+++ b/docs/refining_results.md
@@ -29,19 +29,19 @@ The numbers in brackets next to the values show the number of grants in the sear
     - Using this filter will exclude all non-GBP grants from the search results
   * - Award Date
     - Award Date
-    - The year values are calendar year, not fiscal/financial year, or a range can be selected in the From/To months. See `Ranges <search_bar#searching-ranges>` for how to search between specific dates.
+    - The year values are calendar year, not fiscal/financial year, or a range can be selected in the From/To months. See :ref:`search-ranges` for how to search between specific dates.
   * - Recipient Region
     - This filter is derived from 360Giving data by GrantNav
-    - See also: `GrantNav and location data <locations>`
+    - See also: :doc:`./locations`
   * - Recipient District
     - This filter is derived from 360Giving data by GrantNav
-    - See also: `GrantNav and location data <locations>`
+    - See also: :doc:`./locations`
   * - Funding Organisations
     - Funding Org:Name
     - Values are taken from the data and will change if the funder name changes.
   * - Recipient Organisations
     - Recipient Org:Name
-    - See also: `Organisations in GrantNav <organisations>`
+    - See also: :doc:`./organisations`
   * - Funding Organisation Type
     - tbc
     - Values are taken from tbc 

--- a/docs/search_bar.md
+++ b/docs/search_bar.md
@@ -84,7 +84,9 @@ GrantNav uses the JSON field names rather than the "human-friendly" form that yo
 ```
 
 
-
+```eval_rst
+.. _search-ranges:
+```
 ## Searching Ranges
 
 The search bar allows you to search for a range of dates or values. Commonly, this is used to search by financial year rather than calendar year, or to look for specific ranges of funding values. 


### PR DESCRIPTION
This updates the Refining Results page of the helpsite docs with new information as well as refactors some internal links to :doc: and :ref: in appropriate places, to ensure internal linking works in RST.

The resulting page can be viewed [here](https://help.grantnav.threesixtygiving.org/en/mm-helpsite-fixes/refining_results/#).