### PR TITLE
tests_functional: Remove temp workaround for helpsite error

### DIFF
--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -19,9 +19,6 @@ BROWSER = os.environ.get('BROWSER', 'ChromeHeadless')
 
 def check_js_errors(browser):
     for log in browser.get_log("browser"):
-        # TEMP FIX before helpsite fix is deployed live
-        if "https://help.grantnav.threesixtygiving.org/en/latest/_static/js/theme.js" in log["message"]:
-            continue
         assert "SEVERE" not in log['level'], f"found {log}"
 
 


### PR DESCRIPTION
Remove temp work around for a fix to help.grantnav site that is now live.