### PR TITLE
Passthrough current Grant/Org URL to the Grantee Amendmends form

### DIFF
--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -76,8 +76,7 @@
             This data was originally published by
             <a href="{% url 'publisher' dataset.publisher.prefix %}">{{dataset.publisher.name}}</a>.
             If you see something about your organisation or the funding it has received on this page that doesn't look right you can submit a
-            {% url 'grant' grant.source.id as grant_url_path %}
-            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:grant_url_path|urlencode }}">grantee amendment request</a>.
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.build_absolute_uri|urlencode }}">grantee amendment request</a>.
             You can hover over codes from
             <a href="https://standard.threesixtygiving.org/en/latest/technical/codelists/">standard codelists</a>
             to see the user-friendly name provided by 360Giving.

--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -75,9 +75,9 @@
           <p>
             This data was originally published by
             <a href="{% url 'publisher' dataset.publisher.prefix %}">{{dataset.publisher.name}}</a>.
-            If you see something about your organisation or the funding it has received on this page that doesn&#2019;t look right you can submit a
-            {% url 'grant' grant.source.id as grant_url %}
-            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme }}://{{ request.get_host }}{{ grant_url | urlencode }}">grantee amendment request to them</a>.
+            If you see something about your organisation or the funding it has received on this page that doesn't look right you can submit a
+            {% url 'grant' grant.source.id as grant_url_path %}
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:grant_url_path|urlencode }}">grantee amendment request to them</a>.
             You can hover over codes from
             <a href="https://standard.threesixtygiving.org/en/latest/technical/codelists/">standard codelists</a>
             to see the user-friendly name provided by 360Giving.

--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -77,7 +77,7 @@
             <a href="{% url 'publisher' dataset.publisher.prefix %}">{{dataset.publisher.name}}</a>.
             If you see something about your organisation or the funding it has received on this page that doesn't look right you can submit a
             {% url 'grant' grant.source.id as grant_url_path %}
-            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:grant_url_path|urlencode }}">grantee amendment request to them</a>.
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:grant_url_path|urlencode }}">grantee amendment request</a>.
             You can hover over codes from
             <a href="https://standard.threesixtygiving.org/en/latest/technical/codelists/">standard codelists</a>
             to see the user-friendly name provided by 360Giving.

--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -72,7 +72,16 @@
         <div class="box box--teal">
           <h3 class="box__heading">Where is this data from?</h3>
           {% with dataset=grant|get_dataset %}
-          <p>This data was originally published by <a href="{% url 'publisher' dataset.publisher.prefix %}">{{dataset.publisher.name}}</a>. You can hover over codes from <a href="https://standard.threesixtygiving.org/en/latest/technical/codelists/">standard codelists</a> to see the user-friendly name provided by 360Giving.  If you need to report a problem in the data please contact {{ dataset.publisher.name }} directly, see their <a href="{% url 'publisher' dataset.publisher.prefix %}">GrantNav publisher page</a> for more information.</p>
+          <p>
+            This data was originally published by
+            <a href="{% url 'publisher' dataset.publisher.prefix %}">{{dataset.publisher.name}}</a>.
+            If you see something about your organisation or the funding it has received on this page that doesn&#2019;t look right you can submit a
+            {% url 'grant' grant.source.id as grant_url %}
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme }}://{{ request.get_host }}{{ grant_url | urlencode }}">grantee amendment request to them</a>.
+            You can hover over codes from
+            <a href="https://standard.threesixtygiving.org/en/latest/technical/codelists/">standard codelists</a>
+            to see the user-friendly name provided by 360Giving.
+          </p>
           {% endwith %}
         </div>
       </div>

--- a/grantnav/frontend/templates/org.html
+++ b/grantnav/frontend/templates/org.html
@@ -21,8 +21,7 @@
           <p>
             This data was published in the 360Giving Data Standard by one or more Funders.
             If you see something about your organisation on this page that doesn't look right you can submit a
-            {% url 'org' requested_org_id as org_url_path %}
-            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:org_url_path|urlencode }}">grantee amendment request</a>.
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.build_absolute_uri|urlencode }}">grantee amendment request</a>.
           </p>
         </div>
 

--- a/grantnav/frontend/templates/org.html
+++ b/grantnav/frontend/templates/org.html
@@ -22,7 +22,7 @@
             This data was published in the 360Giving Data Standard by one or more Funders.
             If you see something about your organisation on this page that doesn't look right you can submit a
             {% url 'org' requested_org_id as org_url_path %}
-            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:org_url_path|urlencode }}">grantee amendment request to them</a>.
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:org_url_path|urlencode }}">grantee amendment request</a>.
           </p>
         </div>
 

--- a/grantnav/frontend/templates/org.html
+++ b/grantnav/frontend/templates/org.html
@@ -18,7 +18,12 @@
 
         <div class="box box--teal">
           <h3 class="box__heading">Where is this data from?</h3>
-          <p>This data was published in the 360Giving Data Standard by one or more publishers.</p>
+          <p>
+            This data was published in the 360Giving Data Standard by one or more Funders.
+            If you see something about your organisation on this page that doesn't look right you can submit a
+            {% url 'org' requested_org_id as org_url_path %}
+            <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.scheme|add:"://"|add:request.get_host|add:org_url_path|urlencode }}">grantee amendment request to them</a>.
+          </p>
         </div>
 
         <div class="spacer-2"></div>

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -1227,6 +1227,7 @@ def org(request, org_id):
                "main_name": main_name,
                "other_names": other_names,
                "ftc_data": ftc_data,
+               "requested_org_id": org_id,
                }
 
     return render(request, "org.html", context=context)


### PR DESCRIPTION
This PR:
 * Updates the helptext for the "Where is this data from?" notice on Grant and Org pages.
 * Enables autofill of the GrantNav Link field on grantee amendment form when the form is accessed from grantnav.

Only merge once:
- [x] We've placed the [necessary scripts](https://gist.github.com/R2ZER0/1b03299e3d07d9f8868f8db460fa711c) on the website (guidance & form pages)
- [x] Signoff from Team 360 re. the helptext as displayed in dev grantnav