### PR TITLE
search-summary: Make sure the graph containers wrap correctly

### DIFF
--- a/grantnav/frontend/templates/components/search-summary-box.html
+++ b/grantnav/frontend/templates/components/search-summary-box.html
@@ -20,17 +20,18 @@
       <div class="search-summary--main__left-column">
         <div class="graph-item">
           <div class="graph-label">Amount awarded</div>
-          <div class="graph-container">
+          <div class="graph-container" style="display: inline">
             {% amount_awarded_graph %}
           </div>
         </div>
 
         <div class="graph-item">
           <div class="graph-label">Date awarded</div>
-          <div class="graph-container">
+          <div class="graph-container" style="display: inline">
             {% award_date_graph %}
           </div>
         </div>
+
       </div>
 
 


### PR DESCRIPTION
Quick fix for this issue. Class graph-container is used in the GrantNav embedded widgets and inline is unlikely to be right for this so override for this instance.

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/1087