### PR TITLE
templates: Update data licence information and attribution list

### DIFF
--- a/LICENCE.rst
+++ b/LICENCE.rst
@@ -1,10 +1,6 @@
 GrantNav
 ========
 
-Note: This license doesn't apply to the 360Giving logo </grantnav/frontend/static/images/360-giving-logo-white.svg>. The 360Giving logo is copyright `360Giving <https://threesixtygiving.org>` and may not be used without express permission.
-
-The look-and-feel of GrantNav is that of 360Giving, and care should be taken when running any public instance not to falsely give the impression, intentionally or otherwise, that the instance is operated by or related to 360Giving.
-
 GrantNav is free software designed to help people explore data
 published to the 360Giving Data Standard.
 
@@ -23,21 +19,18 @@ along with GrantNav.  If not, see <https://www.gnu.org/licenses/>.
 
 Copyright 2016-2020 `360Giving <https://threesixtygiving.org>`, a company limited by guarantee 09668396 and a registered charity 1164883.
 
+Logo, look and feel
+-------------------
 
-Code-Point Open
----------------
+The 360Giving logo </grantnav/frontend/static/images/360-giving-logo-white.svg> is excluded
+from the terms of this license. The 360Giving logo is copyright
+`360Giving <https://threesixtygiving.org>` and may not be used without express permission.
 
-GrantNav relies on `Code-Point Open  <https://www.ordnancesurvey.co.uk/business-and-government/products/code-point-open.html>`_ data which is distributed under an `Open Government Licence (v3) <https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>`_
+The look-and-feel of GrantNav is that of 360Giving, and care should be taken when running any public instance not to falsely give the impression, intentionally or otherwise, that the instance is operated by or related to 360Giving.
 
-Contains OS data © Crown copyright and database right 2020
+Data sources
+------------
 
-Contains Royal Mail data © Royal Mail copyright and Database right 2020
-
-Contains National Statistics data © Crown copyright and database right 2020
-
-Northern Ireland Ward to Council Area Lookup
----------------
-
-GrantNav uses `Northern Ireland Ward to Council Area Lookup <https://ons.maps.arcgis.com/home/item.html?id=cce0999ed17f4fbd9f2f5480997405c5>`_ data which is distributed under the `Open Government Licence (v3) <https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>`_
-
-Contains National Statistics data © Crown copyright and database right 2020
+Data published in GrantNav is augmented with data from other sources.
+Attribution and licensing information for additional data sources
+can be found on `the GrantNav datasets page <https://grantnav.threesixtygiving.org/datasets/>`.

--- a/grantnav/frontend/templates/components/footer.html
+++ b/grantnav/frontend/templates/components/footer.html
@@ -82,7 +82,8 @@
     <div class="footer__column-2">
       <p>
         © Copyright 2021 360Giving.<br>
-        Licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.<br>
+        Data in this instance of GrantNav is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>. <a href="{% url 'datasets' %}">Find out more about data sources here</a>.<br>
+        GrantNav source code is free software, licensed under the terms of the <a href="https://www.gnu.org/licenses/">GNU Affero General Public License</a>.
         Running version <a href="https://github.com/OpenDataServices/grantnav/tree/{{request.tag}}">{{request.tag}}</a>.
       </p>
     </div>

--- a/grantnav/frontend/templates/datasets.html
+++ b/grantnav/frontend/templates/datasets.html
@@ -10,30 +10,46 @@
       <section class="prose__section">
         <h1>Data used in GrantNav</h1>
 
-        <p>The data used by GrantNav is open data. GrantNav contains:</p>
-        <ul>
-          <li>Data published to the <a href="https://www.threesixtygiving.org/data-standard/">360Giving Data Standard</a></li>
-          <li>Data derived from <a
-              href="https://www.ordnancesurvey.co.uk/products/code-point-open">Code-Point Open</a>
-          </li>
-          <li>Data derived from <a href="https://register-of-charities.charitycommission.gov.uk/register/full-register-download">Charity Commission data</a></li>
-          <li>Data derived from <a
-              href="https://geoportal.statistics.gov.uk/datasets/ward-to-local-government-district-april-2015-lookup-in-northern-ireland">Northern
-              Ireland Ward to Council Area Lookup</a></li>
-        </ul>
-
         <p>Data published to the 360Giving Data Standard is taken from an <a href="http://data.threesixtygiving.org/">up to date
             list on the 360Giving website</a>. The <a href="/datasets/#datasets-used">360Giving Datasets Used table</a> below
           lists the specific datasets used in GrantNav, how they are licensed, and when they were retrieved.
         </p>
 
-        <p>We use the <a
-            href="https://www.ordnancesurvey.co.uk/products/code-point-open">Code-Point Open</a>
-          data to augment some of the location data. We use the <a
-            href="https://register-of-charities.charitycommission.gov.uk/register/full-register-download">Charity Commission data</a> to look up charity names. Both
-          these datasets are licensed under an <a
-            href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government License</a>.
-        <p>
+        <p>We also augment the data in GrantNav using location and organisation data from other sources. All data from external sources is licensed under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a> unless otherwise specified.</p>
+
+        <h2>Attributions</h2>
+
+        <p>GrantNav contains data derived from:</p>
+
+        <ul>
+          <li><a href="https://www.ons.gov.uk/methodology/geography/licences">postcode data from ONS used under Open Government Licence</a></li>
+          <li>OS data © Crown copyright and database right 2024</li>
+          <li>Royal Mail data © Royal Mail copyright and database right 2024</li>
+          <li>National Statistics data © Crown copyright and database right 2024</li>
+          <li>Northern Ireland postcodes, included based on the Northern Ireland End User Licence. The license covers internal use of the data. Commercial use may require additional permission</li>
+          <li>Northern Ireland Super Output Areas; Northern Ireland Ward Level Population Data (2021), source: <a href="https://www.nisra.gov.uk">NISRA</a></li>
+          <li><a href="https://houseofcommonslibrary.github.io/msoanames/">Middle-Layer Super Output Areas (MSOAs) names</a> licensed under <a href="https://www.parliament.uk/site-information/copyright/open-parliament-licence">Open Parliament Licence</a></li>
+          <li>Scottish Government Intermediate Zone Centroids 2011; Scottish Government Data Zone Centroids 2011: copyright Scottish Government</li>
+          <li>Scotland Ward Level Population Data (2021), source: <a href="https://www.nrscotland.gov.uk">National Records of Scotland</a></li>
+          <li>England and Wales Ward Level Population Data (2022), source: <a href="https://www.ons.gov.uk">Office for National Statistics</a></li>
+          <li><a href="https://www.gov.uk/government/publications/community-amateur-sports-clubs-casc-registered-with-hmrc--2">Community amateur sports clubs (HMRC)</a></li>
+          <li><a href="https://register-of-charities.charitycommission.gov.uk/register/full-register-download">Charity Commission for England and Wales</a></li>
+          <li><a href="http://www.charitycommissionni.org.uk/charity-search/">The Charity Commission for Northern Ireland</a></li>
+          <li><a href="https://www.oscr.org.uk/">Scottish Charity Regulator</a></li>
+          <li><a href="https://download.companieshouse.gov.uk/en_output.html">Companies House Free Company Data Product</a></li>
+          <li><a href="https://mutuals.fca.org.uk/">Mutuals Public Register (FCA)</a></li>
+          <li><a href="https://www.gov.uk/government/organisations">Government Organisation Register (Cabinet Office)</a></li>
+          <li><a href="https://ror.readme.io/docs/data-dump">Research Organization Registry</a> licensed under <a href="https://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Public Domain 1.0 International</a></li>
+          <li><a href="https://www.hesa.ac.uk/">Higher Education Statistics Agency</a> licensed under <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International</a></li>
+          <li><a href="https://ckan.publishing.service.gov.uk/dataset/historical-gov-uk-registers">Local Authorities for England register</a></li>
+          <li><a href="https://ckan.publishing.service.gov.uk/dataset/historical-gov-uk-registers">Local Authorities for Northern Ireland register</a></li>
+          <li><a href="https://ckan.publishing.service.gov.uk/dataset/historical-gov-uk-registers">Scottish Local Authority Register</a></li>
+          <li><a href="https://ckan.publishing.service.gov.uk/dataset/historical-gov-uk-registers">Principle Local Authority Register for Wales</a></li>
+          <li><a href="https://digital.nhs.uk/">NHS Digital</a></li>
+          <li><a href="https://www.gov.uk/government/publications/current-registered-providers-of-social-housing">Registered Social Housing Providers (England)</a><li>
+          <li><a href="https://get-information-schools.service.gov.uk/Downloads">Register of Schools (Department for Education)</a><li>
+          <li><a href="https://gov.wales/address-list-schools">Register of Schools (Wales)</a><li>
+        </ul>
 
         <h2>Updates to data in GrantNav</h2>
 

--- a/grantnav/frontend/templates/datasets.html
+++ b/grantnav/frontend/templates/datasets.html
@@ -34,7 +34,7 @@
           <li>England and Wales Ward Level Population Data (2022), source: <a href="https://www.ons.gov.uk">Office for National Statistics</a></li>
           <li><a href="https://www.gov.uk/government/publications/community-amateur-sports-clubs-casc-registered-with-hmrc--2">Community amateur sports clubs (HMRC)</a></li>
           <li><a href="https://register-of-charities.charitycommission.gov.uk/register/full-register-download">Charity Commission for England and Wales</a></li>
-          <li><a href="http://www.charitycommissionni.org.uk/charity-search/">The Charity Commission for Northern Ireland</a></li>
+          <li><a href="https://www.charitycommissionni.org.uk/charity-search/">The Charity Commission for Northern Ireland</a></li>
           <li><a href="https://www.oscr.org.uk/">Scottish Charity Regulator</a></li>
           <li><a href="https://download.companieshouse.gov.uk/en_output.html">Companies House Free Company Data Product</a></li>
           <li><a href="https://mutuals.fca.org.uk/">Mutuals Public Register (FCA)</a></li>

--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -73,8 +73,9 @@
           <h3 class="box__heading">Where is this data from?</h3>
           {% with dataset=grant|get_dataset %}
           <p>
-            This data was originally published by
+            {% if dataset %}This data was originally published by
             <a href="{% url 'publisher' dataset.publisher.prefix %}">{{dataset.publisher.name}}</a>.
+            {% endif %}
             If you see something about your organisation or the funding it has received on this page that doesn't look right you can submit a
             <a href="https://www.threesixtygiving.org/grantee-amendment-requests/?grantnav_url={{ request.build_absolute_uri|urlencode }}">grantee amendment request</a>.
             You can hover over codes from

--- a/grantnav/frontend/tests_functional.py
+++ b/grantnav/frontend/tests_functional.py
@@ -384,7 +384,6 @@ def test_datasets_page(server_url, browser):
 
 @pytest.mark.parametrize(('path', 'text'), [
     ('/grant/360G-LBFEW-111657', 'Where is this data from?'),
-    ('/grant/360G-LBFEW-111657', 'This data was originally published by')
     ])
 def test_disclaimers(server_url, browser, path, text):
     browser.get(server_url + path)


### PR DESCRIPTION
Updates the [datasets](https://grantnav.threesixtygiving.org/datasets/#reuse) page with attribution statements and licence information for data sources used to enhance grantnav data.

Also updates the footer and LICENSE.rst file for clarity. And refactors the link check tests a bit to make the output more useful when they fail.

Related to #1074