### PR TITLE
Signpost Grantnav Workshops and Modify Sidebar Links

### DIFF
--- a/docs/_templates/_parts/workshops-signpost.html
+++ b/docs/_templates/_parts/workshops-signpost.html
@@ -1,0 +1,4 @@
+<div class="box">
+    <h2 class="box__heading">Want to learn more about how to use GrantNav?</h2>
+    <p>Sign up to our <a href="https://www.threesixtygiving.org/workshops/#free-tools-workshops">Introduction to GrantNav workshops</a> to get the most our of GrantNav's search and use it to answer your biggest grantmaking questions.</p>
+</div>

--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -137,6 +137,7 @@
             <section class="prose__section">
               {% block body %}{% endblock %}
             </section>
+            {% include '_parts/workshops-signpost.html' %}
             {% include '_parts/pagination.html' %}
           </div>
         </div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -21,8 +21,9 @@
 
 <div class="sidebar-content sidebar-content--orange">
   <h3 class="sidebar-content__heading">Useful links</h3>
-  <p class="sidebar-content__text"><a class="" href="https://www.threesixtygiving.org/">360Giving main website</a></p>
-  <p class="sidebar-content__text"><a class="" href="https://dataquality.threesixtygiving.org/">Data Quality Tool</a></p>
+  <p class="sidebar-content__text"><a class="" href="https://www.threesixtygiving.org/workshops/#free-tools-workshops">Workshops</a></p>
+  <p class="sidebar-content__text"><a class="" href="https://www.threesixtygiving.org/publishing/">Publish</a></p>
+  <p class="sidebar-content__text"><a class="" href="https://qualitydashboard.threesixtygiving.org/alldata">Quality Dashboard</a></p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Fixes #1098

- **Docs/templates: Added workshop signpost to base**

This adds a new template which acts as the workshop signpost and then includes it in the base template in an appropriate place.

This was achieved by comparing how the Standard Docs accomplishes the same effect and mimicking it.

- **Docs/templates: Modified "useful links" in sidebar**

Modified the links in the sidebar template to include those requested in #1098
