### PR TITLE
docs: base: Remove non-functional theme option

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -170,11 +170,6 @@
       </footer>
     </div>
 
-  <script type="text/javascript">
-      jQuery(function () {
-          SphinxRtdTheme.StickyNav.enable({{ 'true' if theme_sticky_navigation|tobool else 'false' }});
-      });
-  </script>
   {% block cookieconsent %}
   {% include '_parts/cookie-consent.html' %}
   {% endblock %}


### PR DESCRIPTION
This appears to access an out of scope variable and is actually no longer needed.

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/1117