### PR TITLE
org_utils: Prefer datastore-specified org ids list

### DIFF
--- a/grantnav/frontend/org_utils.py
+++ b/grantnav/frontend/org_utils.py
@@ -38,14 +38,7 @@ def new_ordered_names(org_result):
 
 
 def new_org_ids(org_result):
-    org_ids = [org_result["id"]]
-
-    if org_result["ftcData"]:
-        for org_id in org_result["ftcData"]["orgIDs"]:
-            if org_id not in org_ids:
-                org_ids.append(org_id)
-
-    return org_ids
+    return [org_result["id"], *org_result.get("non_primary_org_ids", [])]
 
 
 class OrgNotFoundError(Exception):


### PR DESCRIPTION
If the loaded data package contains `non_primary_org_ids`, prefer it over `ftcData.orgIDs`.