### PR TITLE
workflows: Pin to specific ubuntu version and remove actions cache

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup python
@@ -11,9 +11,5 @@ jobs:
       with:
         python-version: 3.8
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_docs.txt') }}
     - run: pip install -r requirements_docs.txt
     - run: cd docs; make html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup python
@@ -11,10 +11,6 @@ jobs:
       with:
         python-version: 3.8
         architecture: x64
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}
     - run: pip install -r requirements.txt
     - run: pip install -r requirements_dev.txt
     - run: flake8 .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Setup python
@@ -24,11 +24,5 @@ jobs:
     - run: echo -e '-XX:+DisableExplicitGC\n-Djdk.io.permissionsUseCanonicalPath=true\n-Dlog4j.skipJansi=true\n-server\n' | sudo tee -a /etc/elasticsearch/jvm.options
     - run: sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
     - run: "sudo service elasticsearch start"
-
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements_dev.txt') }}
     - run: pip install -r requirements_dev.txt
-
     - run: ALLOWED_HOSTS=localhost py.test


### PR DESCRIPTION
ubuntu-latest is now changing and actions cache is no longer needed.