### PR TITLE
templates: filter-wrapper: Add missing conditional for Grant Type filter

### DIFF
--- a/grantnav/frontend/templates/components/filter-wrapper.html
+++ b/grantnav/frontend/templates/components/filter-wrapper.html
@@ -26,7 +26,9 @@
         {% include 'components/filters/groups/recipient-filters.html' %}
       {% endif %}
 
-      {% include 'components/filters/lists/filter-list-generic-checkboxes.html' with open=True aggregate_data=results.aggregations.simple_grant_type filter_title="Grant Type" %}
+      {% if results.aggregations.simple_grant_type.buckets %}
+        {% include 'components/filters/lists/filter-list-generic-checkboxes.html' with open=True aggregate_data=results.aggregations.simple_grant_type filter_title="Grant Type" %}
+      {% endif %}
 
     {% endblock filters %}
   </div>


### PR DESCRIPTION
Add missing conditional include if no Grant Type information available for filtering.

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/1003