### PR TITLE
templates: grant: Fix typo on locationScope field comparison

### DIFF
--- a/grantnav/frontend/templates/grant.html
+++ b/grantnav/frontend/templates/grant.html
@@ -130,7 +130,7 @@
                     >{{value}}
                     </a>
 
-                  {% elif "locationScope" in key %}
+                  {% elif "Location Scope" == key %}
                   <a href="https://standard.threesixtygiving.org/en/latest/technical/codelists/#location-scope"
                      title="{{grant.source.additional_data.codeListLookup.locationScope}}"
                      >{{value}}


### PR DESCRIPTION
This should match the key "Location Scope" and not the field name (locationScope).

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/1081