### PR TITLE
Hide long lists of other names behind <details> elements

### DIFF
--- a/grantnav/frontend/templates/components/funder-search-result.html
+++ b/grantnav/frontend/templates/components/funder-search-result.html
@@ -1,5 +1,15 @@
 {% load currency_symbol get_currency get_amount get_title get_name get_date from frontend %}
 
+<style scoped>
+  details summary {
+    cursor: pointer;
+  }
+
+  details[open] summary .temporarily-visible {
+    display: none;
+  }
+</style>
+
 <div class="grant-search-result grant-search-result__funders">
   <div class="grant-search-result__left-side">
       <a class="grant-search-result__title" href="{% url 'org' result.source.id %}">
@@ -35,8 +45,21 @@
 
     {% if result.names|length > 1 %}
     <div class="grant-search-result__data-item">
-      <span class="grant-search-result__data-item--label">Other Names used in the data: </span>
-      <span>{{result.other_names | join:"; "}}</span>
+      {% if result.other_names|join:"; "|length > 400 %}
+        <details>
+          <summary>
+            <span class="grant-search-result__data-item--label">Other Names used in the data: </span>
+            <span class="temporarily-visible">
+              <br/>
+              {{result.other_names|join:"; "|slice:":400"}}&hellip;
+            </span>
+          </summary>
+          <span>{{result.other_names|join:"; "}}</span>
+        </details>
+        {% else %}
+        <span class="grant-search-result__data-item--label">Other Names used in the data: </span>
+        <span>{{result.other_names|join:"; "}}</span>
+      {% endif %}
     </div>
     {% endif %}
 

--- a/grantnav/frontend/templates/components/recipient-search-result.html
+++ b/grantnav/frontend/templates/components/recipient-search-result.html
@@ -1,5 +1,15 @@
 {% load currency_symbol get_currency get_amount get_title get_name get_date from frontend %}
 
+<style scoped>
+  details summary {
+    cursor: pointer;
+  }
+
+  details[open] summary .temporarily-visible {
+    display: none;
+  }
+</style>
+
 <div class="grant-search-result grant-search-result__recipients">
   <div class="grant-search-result__left-side">
       <a class="grant-search-result__title" href="{% url 'org' result.source.id %}">
@@ -36,8 +46,21 @@
 
     {% if result.names|length > 1 %}
     <div class="grant-search-result__data-item">
-      <span class="grant-search-result__data-item--label">Other Names used in the data: </span>
-      <span>{{result.other_names | join:"; "}}</span>
+      {% if result.other_names|join:"; "|length > 400 %}
+        <details>
+          <summary>
+            <span class="grant-search-result__data-item--label">Other Names used in the data: </span>
+            <span class="temporarily-visible">
+              <br/>
+              {{result.other_names|join:"; "|slice:":400"}}&hellip;
+            </span>
+          </summary>
+          <span>{{result.other_names|join:"; "}}</span>
+        </details>
+        {% else %}
+        <span class="grant-search-result__data-item--label">Other Names used in the data: </span>
+        <span>{{result.other_names|join:"; "}}</span>
+      {% endif %}
     </div>
     {% endif %}
 

--- a/grantnav/frontend/templates/org.html
+++ b/grantnav/frontend/templates/org.html
@@ -3,6 +3,17 @@
 {% load static %}
 {% block subtitle %} - {{main_name}}{% endblock %}
 {% block main_content %}
+
+<style scoped>
+  details summary {
+    cursor: pointer;
+  }
+
+  details[open] summary .temporarily-visible {
+    display: none;
+  }
+</style>
+
 <div class="layout layout--single-column">
   <main class="layout__content">
     <div class="spacer-1">
@@ -43,8 +54,21 @@
 
           {% if other_names %}
           <div class="media-card__box">
+            {% if other_names|join:"; "|length > 400 %}
+            <details>
+              <summary>
+                <strong>Other Names used in the data</strong>
+                <span class="temporarily-visible">
+                  <br/>
+                  {{other_names|join:"; "|slice:":400"}}&hellip;
+                </span>
+              </summary>
+              {{other_names|join:"; "}}
+            </details>
+            {% else %}
             <strong>Other Names used in the data</strong> <br/>
-            {{other_names|join:"; "}}
+              {{other_names|join:"; "}}
+            {% endif %}
           </div>
           {% endif %}
         </div>


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/a3d0b049-d530-429d-b15d-5651e821cb69)

After:
![image](https://github.com/user-attachments/assets/77dc0248-0718-491f-9bee-a45bcb634a4d)

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/896