### PR TITLE
Add Coveralls

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,7 @@ jobs:
     - run: sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
     - run: "sudo service elasticsearch start"
     - run: pip install -r requirements_dev.txt
-    - run: ./manage.py test -v 2 tests --exclude-tag=link-runner
+    - run: coverage run --source='./grantnav' ./manage.py test -v 2 tests --exclude-tag=link-runner
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: coveralls --service=github


### PR DESCRIPTION
Only to test.yml, not test_links.yml

The latest version of the library was already included in requirements

https://github.com/ThreeSixtyGiving/grantnav/issues/1155