### PR TITLE
Fix url path issue cause by Django upgrade

### DIFF
--- a/grantnav/api/urls.py
+++ b/grantnav/api/urls.py
@@ -1,8 +1,8 @@
-from django.urls import path
+from django.urls import re_path
 import grantnav.api.aggregates
 
 app_name = "api"
 
 urlpatterns = [
-    path("aggregates/search", grantnav.api.aggregates.Search.as_view(), name="aggregates"),
+    re_path(r"^aggregates/search", grantnav.api.aggregates.Search.as_view(), name="aggregates"),
 ]


### PR DESCRIPTION
Replace path with re_path in grantnav/api/urls.py as extra .aggregates_api on end of path means re_path needed