### PR TITLE
frontend: templates: Add ids and anchor hashes to all filters

### DIFF
--- a/grantnav/frontend/templates/components/filters/lists/filter-list-amount-awarded.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-amount-awarded.html
@@ -1,13 +1,13 @@
 {% load get_amount_range get_amount from frontend %}
 <div class="filter-list margin-bottom:2">
-  <details class="filter-list__accordion" open>
+  <details id="filter-accordion-amount-awarded" class="filter-list__accordion" open>
     <summary class="filter-list__label">
       <div>Amount Awarded ({{current_currency}}) {% if results.aggregations.amountAwardedFixed.clear_url %} <a href="{{results.aggregations.amountAwardedFixed.clear_url}}"> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}
     </summary>
     <div class="filter-list__contents-wrapper">
       {% block filterForm %}
-        <form class="filter-list__contents--form">
+        <form id="filter-form-amount-awarded" class="filter-list__contents--form">
           <div class="filter-list__contents--form-item">
             <label for="min-amount">Smallest (£)</label>
             <input id="min-amount" name="new_min_amount" class="form-control" value="{{query.query.bool.filter.3.bool.should.range.amountAwarded.gte}}"/>
@@ -24,7 +24,7 @@
         {% if not query.query.bool.filter.3.bool.should.range.amountAwarded %}
           {% for bucket in results.aggregations.amountAwardedFixed.buckets %}
             <li>
-              <a class="filter-list__filter-item {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}" id="amount-{{bucket.key|lower}}">
+              <a class="filter-list__filter-item {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}#filter-accordion-amount-awarded" id="amount-{{bucket.key|lower}}">
                 {{bucket|get_amount_range:current_currency}} <small>({{bucket.doc_count|get_amount}})</small>
 
                 {% if bucket.selected %}
@@ -38,3 +38,14 @@
     </div>
   </details>
 </div>
+
+<script>
+  document.querySelector('#filter-form-amount-awarded').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const url = e.target.action;
+    const hash = '#filter-accordion-amount-awarded';
+
+    e.target.action = url + hash;
+    e.target.submit();
+  });
+</script>

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-district.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-district.html
@@ -1,5 +1,5 @@
 <div class="filter-list filter-list--with-checkboxes">
-  <details class="filter-list__accordion" {% if results.aggregations.recipientDistrictName.clear_url or open %} open{% endif %}>
+  <details id="filter-accordion-district" class="filter-list__accordion" {% if results.aggregations.recipientDistrictName.clear_url or open %} open{% endif %}>
     <summary class="filter-list__label">
       <div>District {% if results.aggregations.recipientDistrictName.clear_url %} <a href={{results.aggregations.recipientDistrictName.clear_url}}> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-funding-org.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-funding-org.html
@@ -1,6 +1,6 @@
 {% load get_facet_org_name get_facet_org_id get_amount from frontend %}
 <div class="filter-list filter-list--with-checkboxes">
-  <details class="filter-list__accordion" {% if results.aggregations.fundingOrganization.clear_url or True %} open{% endif %}>
+  <details id="filter-accordion-funding-org" class="filter-list__accordion" {% if results.aggregations.fundingOrganization.clear_url or True %} open{% endif %}>
     <summary class="filter-list__label">
       <div>Funding Organisations {% if results.aggregations.fundingOrganization.clear_url %} <a href={{results.aggregations.fundingOrganization.clear_url}}> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-generic-checkboxes.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-generic-checkboxes.html
@@ -12,7 +12,7 @@
       <ul class="filter-list__listing" {% if finder %}style="height: 250px" {% endif %}>
           {% for bucket in aggregate_data.buckets %}
           <li>
-            <a class="filter-list__filter-item {% if finder %}filter-list-{{finder_class}}{% endif %} {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}" id="filter-option-{{filter_title|lower|cut:' '}}-{{bucket.key|lower}}" >
+            <a class="filter-list__filter-item {% if finder %}filter-list-{{finder_class}}{% endif %} {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}#filter-accordion-{{filter_title|lower|cut:' '}}" id="filter-option-{{filter_title|lower|cut:' '}}-{{bucket.key|lower}}" >
               {{bucket.key}} <small>({{bucket.doc_count|get_amount}})</small>
 
               {% if bucket.selected %}

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-generic-include-exclude.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-generic-include-exclude.html
@@ -6,7 +6,7 @@
 {% endcomment %}
 {% load concat from frontend %}
 <div class="filter-list filter-list--with-checkboxes">
-  <details class="filter-list__accordion" {% if aggregate_data.clear_url or open %} open{% endif %}>
+  <details id="filter-accordion-{{filter_title|lower|cut:' '}}" class="filter-list__accordion" {% if aggregate_data.clear_url or open %} open{% endif %}>
     <summary class="filter-list__label">
       <div>{{filter_title}} {% if aggregate_data.clear_url %} <a href={{aggregate_data.clear_url}}> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-programme-title.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-programme-title.html
@@ -1,6 +1,6 @@
 {% load get_facet_org_name get_facet_org_id get_amount from frontend %}
 <div class="filter-list filter-list--with-checkboxes margin-bottom:2">
-  <details class="filter-list__accordion" {% if results.aggregations.grantProgramme.clear_url %} open{% endif %}>
+  <details id="filter-accordion-programme-title" class="filter-list__accordion" {% if results.aggregations.grantProgramme.clear_url %} open{% endif %}>
     <summary class="filter-list__label">
       <div>Grant Programme Title {% if results.aggregations.grantProgramme.clear_url %} <a href={{results.aggregations.grantProgramme.clear_url}}> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-recipient-org-type.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-recipient-org-type.html
@@ -1,6 +1,6 @@
 {% load get_facet_org_name get_amount from frontend %}
 <div class="filter-list">
-  <details class="filter-list__accordion" open>
+  <details id="filter-accordion-recipient-org-type" class="filter-list__accordion" open>
     <summary class="filter-list__label">
       <div>Type of Recipient {% if results.aggregations.recipientTSGType.clear_url %} <a href={{results.aggregations.recipientTSGType.clear_url}}> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}
@@ -11,7 +11,7 @@
       <ul class="filter-list__listing">
           {% for bucket in results.aggregations.recipientTSGType.buckets %}
             <li>
-            <a class="filter-list__filter-item {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}">
+            <a class="filter-list__filter-item {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}#filter-accordion-recipient-org-type">
               {{bucket.key}} <small>({{bucket.doc_count|get_amount}})</small>
               {% if bucket.selected %}
                 <span class="screen-reader-only">(active filter)</span>

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-recipient-org.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-recipient-org.html
@@ -1,6 +1,6 @@
 {% load get_facet_org_name get_facet_org_id get_amount from frontend %}
 <div class="filter-list filter-list--with-checkboxes">
-  <details class="filter-list__accordion" {% if results.aggregations.recipientOrganization.clear_url %} open{% endif %}>
+  <details id="filter-accordion-recipient-org" class="filter-list__accordion" {% if results.aggregations.recipientOrganization.clear_url %} open{% endif %}>
     <summary class="filter-list__label">
       <div>Recipient Organisations {% if results.aggregations.recipientOrganization.clear_url %} <a href={{results.aggregations.recipientOrganization.clear_url}}> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-year.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-year.html
@@ -1,14 +1,14 @@
 {% load frontend %}
 
 <div class="filter-list margin-bottom:2">
-  <details class="filter-list__accordion" open>
+  <details id="filter-accordion-year" class="filter-list__accordion" open>
     <summary class="filter-list__label">
       <div>Award Date {% if results.aggregations.awardYear.clear_url %} <a href="{{results.aggregations.awardYear.clear_url}}"> <small>(clear)</small></a> {% endif%}</div>
       {% include 'tokens/accordion-toggle-icon.html' %}
     </summary>
     <div class="filter-list__contents-wrapper">
       {% block filterForm %}
-        <form class="filter-list__contents--form">
+        <form id="filter-form-year" class="filter-list__contents--form">
 
           <span class="input-daterange input-group" id="datepicker">
             <div class="filter-list__contents--form-item">
@@ -35,7 +35,7 @@
          {% if not query.query.bool.filter.9.bool.should.range.awardDate %}
          {% for bucket in results.aggregations.awardYear.buckets %}
           <li>
-            <a class="filter-list__filter-item {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}">
+            <a class="filter-list__filter-item {% if bucket.selected %} active{% endif %}" href="{{bucket.url}}#filter-accordion-year">
               {% if bucket.from_as_string %} {{bucket.from_as_string}} {% else %} {{bucket.key_as_string}} {% endif %} <small>({{bucket.doc_count|get_amount}})</small>
               {% if bucket.selected %}
                 <span class="screen-reader-only">(active filter)</span>
@@ -48,3 +48,14 @@
     </div>
   </details>
 </div>
+
+<script>
+  document.querySelector('#filter-form-year').addEventListener('submit', (e) => {
+    e.preventDefault();
+    const url = e.target.action;
+    const hash = '#filter-accordion-year';
+
+    e.target.action = url + hash;
+    e.target.submit();
+  });
+</script>

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -228,7 +228,7 @@ function get_filter_search_ajax (parent_field, child_field) {
 }
 
 // when a new item is selected then refresh the page
-function redirect_on_selection (param, data) {
+function redirect_on_selection (id, param, data) {
   show_overlay();
   /* Ajax route OR template route */
   const url = data.url || data.element.dataset.url;
@@ -239,12 +239,13 @@ function redirect_on_selection (param, data) {
   if ($('#' + param + '-exclude').prop('checked')) {
     uri.addSearch('exclude_' + param, 'true');
   }
+  uri.fragment(id);
   window.location.href = uri.toString();
 }
 
 // refresh the page when moving from exclude to include selection.
 // BUT do not do this if there is no curent selection
-function maybe_redirect_on_exclude (param) {
+function maybe_redirect_on_exclude (id, param) {
   if ($('.' + param + '-search-box').select2('data').length === 0) {
     return;
   }
@@ -258,6 +259,7 @@ function maybe_redirect_on_exclude (param) {
   if ($('#' + param + '-exclude').prop('checked')) {
     uri.addSearch('exclude_' + param, 'true');
   }
+  uri.fragment(id);
   window.location.href = uri.toString();
 }
 
@@ -328,32 +330,38 @@ $(function () {
     /* Selecting */
     $('.fundingOrganization-search-box').on('select2:select', function (e) {
       const data = e.params.data;
-      redirect_on_selection('fundingOrganization', data);
+      const parentFilterId = e.target.closest('details').id || '';
+      redirect_on_selection(parentFilterId, 'fundingOrganization', data);
     });
 
     $('.recipientOrganization-search-box').on('select2:select', function (e) {
       const data = e.params.data;
-      redirect_on_selection('recipientOrganization', data);
+      const parentFilterId = e.target.closest('details').id || '';
+      redirect_on_selection(parentFilterId, 'recipientOrganization', data);
     });
 
     $('.grantProgramme-search-box').on('select2:select', function (e) {
       const data = e.params.data;
-      redirect_on_selection('grantProgramme', data);
+      const parentFilterId = e.target.closest('details').id || '';
+      redirect_on_selection(parentFilterId, 'grantProgramme', data);
     });
 
     $('.recipientDistrictName-search-box').on('select2:select', function (e) {
       const data = e.params.data;
-      redirect_on_selection('recipientDistrictName', data);
+      const parentFilterId = e.target.closest('details').id || '';
+      redirect_on_selection(parentFilterId, 'recipientDistrictName', data);
     });
 
     $('.recipientOrgDistrictName-search-box').on('select2:select', function (e) {
       const data = e.params.data;
-      redirect_on_selection('recipientOrgDistrictName', data);
+      const parentFilterId = e.target.closest('details').id || '';
+      redirect_on_selection(parentFilterId, 'recipientOrgDistrictName', data);
     });
 
     $('.beneficiaryDistrictName-search-box').on('select2:select', function (e) {
       const data = e.params.data;
-      redirect_on_selection('beneficiaryDistrictName', data);
+      const parentFilterId = e.target.closest('details').id || '';
+      redirect_on_selection(parentFilterId, 'beneficiaryDistrictName', data);
     });
 
     /* End selecting */
@@ -361,27 +369,33 @@ $(function () {
     /* Excluding */
 
     $('#fundingOrganization-select input[type=radio]').on('change', function (e) {
-      maybe_redirect_on_exclude('fundingOrganization');
+      const parentFilterId = e.target.closest('details').id || '';
+      maybe_redirect_on_exclude(parentFilterId, 'fundingOrganization');
     });
 
     $('#recipientOrganization-select input[type=radio]').on('change', function (e) {
-      maybe_redirect_on_exclude('recipientOrganization');
+      const parentFilterId = e.target.closest('details').id || '';
+      maybe_redirect_on_exclude(parentFilterId, 'recipientOrganization');
     });
 
     $('#grantProgramme-select input[type=radio]').on('change', function (e) {
-      maybe_redirect_on_exclude('grantProgramme');
+      const parentFilterId = e.target.closest('details').id || '';
+      maybe_redirect_on_exclude(parentFilterId, 'grantProgramme');
     });
 
     $('#recipientDistrictName-select input[type=radio]').on('change', function (e) {
-      maybe_redirect_on_exclude('recipientDistrictName');
+      const parentFilterId = e.target.closest('details').id || '';
+      maybe_redirect_on_exclude(parentFilterId, 'recipientDistrictName');
     });
 
     $('#recipientOrgDistrictName-select input[type=radio]').on('change', function (e) {
-      maybe_redirect_on_exclude('recipientOrgDistrictName');
+      const parentFilterId = e.target.closest('details').id || '';
+      maybe_redirect_on_exclude(parentFilterId, 'recipientOrgDistrictName');
     });
 
     $('#beneficiaryDistrictName-select input[type=radio]').on('change', function (e) {
-      maybe_redirect_on_exclude('beneficiaryDistrictName');
+      const parentFilterId = e.target.closest('details').id || '';
+      maybe_redirect_on_exclude(parentFilterId, 'beneficiaryDistrictName');
     });
 
     /* End excluding */


### PR DESCRIPTION
Fixes #961

Ids are added to filter parent details elements, then all anchors and javascript-triggered page reloads are injected with that id as an anchor hash.