### PR TITLE
Add CORS headers to api

### DIFF
--- a/grantnav/api/__init__.py
+++ b/grantnav/api/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "grantnav.api.apps.APIConfig"

--- a/grantnav/api/apps.py
+++ b/grantnav/api/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class APIConfig(AppConfig):
+    name = "grantnav.api"
+
+    def ready(self):
+        # Makes sure all signal handlers are connected
+        #logger.error(f"Importing corsheader signal handler")
+        from grantnav.api import handlers  # noqa

--- a/grantnav/api/handlers.py
+++ b/grantnav/api/handlers.py
@@ -1,0 +1,12 @@
+from corsheaders.signals import check_request_enabled
+
+
+def cors_allow_api_to_all_360(sender, request, **kwargs):
+    if request.path.startswith("/api/"):
+        if "Origin" in request.headers:
+            if request.headers["Origin"].endswith(".threesixtygiving.org"):
+                return True
+    return False
+
+
+check_request_enabled.connect(cors_allow_api_to_all_360)

--- a/grantnav/settings.py
+++ b/grantnav/settings.py
@@ -80,16 +80,15 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'bootstrap3',
+    'corsheaders',
     'grantnav.frontend',
     'grantnav.prometheus',
     'grantnav.api',
     'raven.contrib.django.raven_compat',
 )
 
-if DEBUG:
-    INSTALLED_APPS = INSTALLED_APPS + ("corsheaders",)
-
 MIDDLEWARE = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -98,9 +97,6 @@ MIDDLEWARE = (
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
-
-if DEBUG:
-    MIDDLEWARE = ("corsheaders.middleware.CorsMiddleware",) + MIDDLEWARE
 
 ROOT_URLCONF = 'grantnav.urls'
 

--- a/requirements.in
+++ b/requirements.in
@@ -13,3 +13,4 @@ prometheus_client==0.7
 retry
 plotly
 millify
+django-cors-headers

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile requirements.in
 #
 asgiref==3.8.1
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 backports-datetime-fromisoformat==2.0.3
     # via flattentool
 backports-zoneinfo==0.2.1
@@ -26,7 +28,10 @@ django==4.2.20
     # via
     #   -r requirements.in
     #   django-bootstrap3
+    #   django-cors-headers
 django-bootstrap3==24.3
+    # via -r requirements.in
+django-cors-headers==4.4.0
     # via -r requirements.in
 django-environ==0.11.2
     # via -r requirements.in

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -6,5 +6,4 @@ coveralls
 selenium
 libsass
 chromedriver-autoinstaller
-django-cors-headers
 black

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -52,7 +52,7 @@ django==4.2.20
 django-bootstrap3==24.3
     # via -r requirements.in
 django-cors-headers==4.4.0
-    # via -r requirements_dev.in
+    # via -r requirements.in
 django-environ==0.11.2
     # via -r requirements.in
 docopt==0.6.2


### PR DESCRIPTION
For /api requests where Origin is threesixtygiving.org domains using django-cors-headers https://github.com/ThreeSixtyGiving/grantnav/issues/1033