### PR TITLE
context_processors/footer: Add current_year {{current_year}}

### DIFF
--- a/grantnav/frontend/context_processors.py
+++ b/grantnav/frontend/context_processors.py
@@ -1,7 +1,7 @@
 import os.path
+import datetime
 
 from django.conf import settings
-from os.path import getmtime
 
 
 def piwik(request):
@@ -20,7 +20,7 @@ def navigation(request):
 
 # This is calculated here and not in the main_css_cache_key() function so that it is only checked once per process.
 # Checking once per request is an unnecessary performance hit.
-MAIN_CSS_CACHE_KEY = getmtime(os.path.join(settings.BASE_DIR, 'grantnav', 'frontend', 'static', 'css', 'main.css'))
+MAIN_CSS_CACHE_KEY = os.path.getmtime(os.path.join(settings.BASE_DIR, 'grantnav', 'frontend', 'static', 'css', 'main.css'))
 
 
 def main_css_cache_key(request):
@@ -37,3 +37,7 @@ def insights_url(request):
 
 def disable_cookie_popup(request):
     return {"disable_cookie_popup": settings.DISABLE_COOKIE_POPUP}
+
+
+def current_year(request):
+    return {"current_year": datetime.datetime.now().year}

--- a/grantnav/frontend/templates/components/footer.html
+++ b/grantnav/frontend/templates/components/footer.html
@@ -87,7 +87,7 @@
 
     <div class="footer__column-2">
       <p>
-        © Copyright 2021 360Giving.<br>
+        © Copyright {{current_year}} 360Giving.<br>
         Data in this instance of GrantNav is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>. <a href="{% url 'datasets' %}">Find out more about data sources here</a>.<br>
         GrantNav source code is free software, licensed under the terms of the <a href="https://www.gnu.org/licenses/">GNU Affero General Public License</a>.
       </p>

--- a/grantnav/frontend/templates/datasets.html
+++ b/grantnav/frontend/templates/datasets.html
@@ -17,7 +17,7 @@
 
         <p>We also augment the data in GrantNav using location and organisation data from other sources. All data from external sources is licensed under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence v3.0</a> unless otherwise specified.</p>
 
-        <h2>Attributions</h2>
+        <h2 id="attributions">Attributions</h2>
 
         <p>GrantNav contains data derived from:</p>
 

--- a/grantnav/settings.py
+++ b/grantnav/settings.py
@@ -120,6 +120,7 @@ TEMPLATES = [
                 'grantnav.frontend.context_processors.debug_mode',
                 'grantnav.frontend.context_processors.insights_url',
                 'grantnav.frontend.context_processors.disable_cookie_popup',
+                'grantnav.frontend.context_processors.current_year',
             ],
         },
     },


### PR DESCRIPTION
This updates the footer to use current year from the server so that we don't need to update this in the future.

Also fix double import of os.path