### PR TITLE
templates: base: Add workaround for static url hardcoded in CSS

### DIFF
--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -31,6 +31,22 @@
 
     {% include "components/favicons.html" %}
 
+
+    {# temp workaround for hardcoded background-url values in 360-ds which don't pick up dynamic static location #}
+    <style>
+    .filter-list__filter-item::after {
+      background: url("{% static 'images/checkmark-icon.svg' %}") no-repeat !important;
+    }
+
+    .filter-list--with-checkboxes .filter-list__form--checkbox-item label::after {
+      background: url("{% static 'images/checkmark-icon.svg' %}") no-repeat !important;
+    }
+
+    select.front_search {
+      background: #d66f05 url("{% static 'images/arrow.png' %}") no-repeat scroll 98% center/15% auto !important;
+    }
+    </style>
+
     </head>
     <body>
         <!--[if lt IE 8]>


### PR DESCRIPTION
The CSS has static url items which aren't able change with the settings in django in deployment for serving the static locations. So override them in the template.

https://github.com/ThreeSixtyGiving/grantnav/blob/live/grantnav/frontend/static/css/main.css#L1762

This isn't a hugely sustainable approach, however these css rules are due to be replaced so a temporary solution is called for here (fixes 404 in live).