### PR TITLE
templates: search: Remove touchstart handler for loading overlay

### DIFF
--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -169,7 +169,6 @@ $(document).ready(function () {
   filters.forEach(function (filter) {
     // Add event listeners for click and touch events
     filter.addEventListener('click', show_overlay);
-    filter.addEventListener('touchstart', show_overlay);
 
     // Add event listener for keyboard events
     filter.addEventListener('keydown', function (event) {


### PR DESCRIPTION
The touchstart function loads the overlay which is at a higher z-index than then element to be clicked. So the overlay loads but the element (usually a filter item) beneath the overlay doesn't receive a "click"

Fixes: https://github.com/ThreeSixtyGiving/grantnav/issues/1188