### PR TITLE
frontend: templates: Add key/val for search/filters based on forms

### DIFF
--- a/grantnav/frontend/templates/components/filters/lists/filter-list-amount-awarded.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-amount-awarded.html
@@ -16,6 +16,7 @@
             <label for="max-amount">Largest (£)</label>
             <input id="max-amount" name="new_max_amount" class="form-control input-xs" value="{{query.query.bool.filter.3.bool.should.range.amountAwarded.lte}}"/>
           </div>
+          <input type="hidden" name="a" value="1">
           <input name="json_query" class="form-control" type="hidden" value="{{json_query}}">
           <button type="submit" class="filter-list__contents--form-submit">Apply</button>
         </form>

--- a/grantnav/frontend/templates/components/filters/lists/filter-list-year.html
+++ b/grantnav/frontend/templates/components/filters/lists/filter-list-year.html
@@ -22,7 +22,7 @@
             </div>
           </span>
 
-
+          <input type="hidden" name="a" value="1">
           <input name="json_query" class="form-control" type="hidden" value="{{json_query}}">
           <button type="submit" class="filter-list__contents--form-submit">Apply</button>
 

--- a/grantnav/frontend/templates/components/search-block--advanced.html
+++ b/grantnav/frontend/templates/components/search-block--advanced.html
@@ -13,6 +13,7 @@
       <div class="search-block__form-group">
           <input name="text_query" class="form-control large-search" placeholder="Search grants, funders, recipients, locations" type="text" value="{{text_query}}">
           <input name="json_query" class="form-control" type="hidden" value="{{json_query}}">
+         <input type="hidden" name="a" value="1">
       </div>
       <div class="search-block__form-radio-group">
         <div class="search-block__form-group-label">

--- a/grantnav/frontend/templates/components/search-block.html
+++ b/grantnav/frontend/templates/components/search-block.html
@@ -13,6 +13,7 @@
           <input name="text_query" class="form-control large-search" placeholder="Search grants, funders, recipients, locations" type="text" value="{{text_query}}">
           <input class="large-search-button" name="submit" type="submit" value="Search">
           <input name="json_query" class="form-control" type="hidden" value="{{json_query}}">
+          <input type="hidden" name="a" value="1">
         </div>
       </form>
     </div>

--- a/grantnav/frontend/templates/search.html
+++ b/grantnav/frontend/templates/search.html
@@ -206,6 +206,7 @@ $(document).ready(function () {
     } else if (this.value === 'table') {
       urlParams.set('view_mode', 'table');
     }
+    urlParams.set('a', '1');
     window.location.search = urlParams;
   });
 });


### PR DESCRIPTION
Forms such as text search or filters such as amount min/max [Apply] aren't links in the filters so need to the key added manually.

Continuation of abc55e7dfbdf2d0f52f256b357caf240a8acd9a3