### PR TITLE
Mw/org page stats by recipient type

### DIFF
--- a/grantnav/frontend/org_utils.py
+++ b/grantnav/frontend/org_utils.py
@@ -2,15 +2,22 @@ from grantnav.frontend.search_helpers import get_results
 
 
 def new_stats_by_currency(org_result):
-    """ Takes a org dict and creates a sorted and ease of use in templates list"""
+    """ Takes a org dict and creates a sorted list of currencies for ease of use in templates"""
     stats_by_currency = []
 
-    for currency, stat in org_result["aggregate"]["currencies"].items():
-        stat["currency"] = currency
-        stats_by_currency.append(stat)
+    for recipient_type in ["recipient_org", "recipient_ind"]:
+        try:
+            for currency, stat in org_result["aggregate"]["currencies"].items():
+                stat["currency"] = currency
+                # Copy the currency name for convenience in the list
+                stat[recipient_type]["currency"] = currency
+                stat[recipient_type]["recipient_type"] = recipient_type
+                stats_by_currency.append(stat[recipient_type])
+        except KeyError:
+            continue
 
-    # sort the list with the largest total amount currency first
-    stats_by_currency.sort(key=lambda i: i["total"], reverse=True)
+        # sort the list with the largest total amount currency first
+        stats_by_currency.sort(key=lambda i: i["total"], reverse=True)
 
     return stats_by_currency
 

--- a/grantnav/frontend/templates/components/funder-search-result.html
+++ b/grantnav/frontend/templates/components/funder-search-result.html
@@ -16,24 +16,39 @@
         {{ result.names.0 }}
       </a>
     <div class="grant-search-result__box_container">
-      {% for stat in result.stats_by_currency %}
+      <!--      <pre>{{result}}</pre> -->
         <div class="grant-search-result__box" style="padding-bottom:0">
-          <strong>Grants {%if stat.currency != 'GBP' or result.stats_by_currency|length > 1%} <br /><small>{{stat.currency}}</small> {% endif %}</strong><br/>
-          {{stat.grants | get_amount }}
+          <strong>All Grants Funded<br /></strong>
+          {{result.source.aggregate.grants | get_amount }}
         </div>
+
+        {% if result.source.aggregate.grants_org %}
         <div class="grant-search-result__box" style="padding-bottom:0">
-          <strong>Total {%if stat.currency != 'GBP' or result.stats_by_currency|length > 1 %} <br /><small>{{stat.currency}}</small>{% endif %}</strong><br/>
+            <strong>Recipient Organisations</strong> <br />
+            {{result.source.aggregate.grants_org | get_amount }}
+        </div>
+        {% endif %}
+
+        <div class="grant-search-result__box" style="padding-bottom:0">
+            <strong>Grants to Individuals</strong> <br />
+            {{result.source.aggregate.grants_ind | get_amount }}
+        </div>
+
+        {% if result.source.currency|length > 1 %}
+        <div class="grant-search-result__box" style="padding-bottom:0">
+            <strong>Grant Currencies</strong> <br />
+            {{result.source.currency | length | get_amount }}
+        </div>
+        {% else %}
+      {% for stat in result.stats_by_currency %}
+        {% if stat.currency == 'GBP' %}
+        <div class="grant-search-result__box" style="padding-bottom:0">
+          <strong>Total {% if stat.recipient_type == "recipient_org"%} to Organisations {% elif stat.recipient_type == "recipient_ind" %}to Individuals{% endif %}</strong><br/>
           {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
         </div>
-        <div class="grant-search-result__box" style="padding-bottom:0">
-          <strong>Greatest {%if stat.currency != 'GBP' or result.stats_by_currency|length > 1 %} <br /><small>{{stat.currency}}</small> {% endif %}</strong><br/>
-          {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
-        </div>
-        <div class="grant-search-result__box" style="padding-bottom:0">
-          <strong>Smallest {%if stat.currency != 'GBP' or result.stats_by_currency|length > 1 %} <br /> <small>{{stat.currency}}</small> {% endif %}</strong><br/>
-          {{stat.currency | currency_symbol}}{{stat.min | get_amount}}
-        </div>
+        {% endif %}
       {% endfor %}
+      {% endif %}
     </div>
   </div>
 
@@ -66,6 +81,11 @@
     <div class="grant-search-result__data-item">
       <span class="grant-search-result__data-item--label">Latest Award: </span>
       <span>{{ result.source.aggregate.maxAwardDate | get_date}}</span>
+    </div>
+
+    <div class="grant-search-result__data-item">
+      <span class="grant-search-result__data-item--label">Earliest Award: </span>
+      <span>{{ result.source.aggregate.minAwardDate | get_date}}</span>
     </div>
 
 

--- a/grantnav/frontend/templates/components/org-page-funder.html
+++ b/grantnav/frontend/templates/components/org-page-funder.html
@@ -1,21 +1,32 @@
 {% load frontend %}
-
 <article class="media-card media-card--teal">
   <div class="media-card__content_no_image">
     <header class="media-card__header">
         <h3 class="media-card__heading" id="Funder">As Funder</h3>
     </header>
-    <p>{{org_names.0}} appears in the 360Giving data as a funder of grants. Here is an overview of the grants they have funded.</p>
     <h4>Summary</h4>
+    <p>{{org_names.0}} appears in the 360Giving data as a funder of grants.
+    Here is an overview of the grants they have funded.</p>
     <div class="media-card__box_container">
         <div class="media-card__box">
             <strong>Total Grants</strong> <br />
             <span style="word-break: break-all">{{funder.aggregate.grants | get_amount }}</span>
         </div>
+        {# Only funds grants to org #}
+        {% if funder.aggregate.grants_org and not funder.aggregate.grants_ind %}
         <div class="media-card__box">
-            <strong>Recipients</strong> <br />
-            {{funder.recipients | get_amount }}
+            <strong>Recipient Organisations</strong> <br />
+            {{funder.aggregate.grants_org | get_amount }}
         </div>
+        {% endif %}
+
+        {# Only funds grants to ind #}
+        {% if funder.aggregate.grants_ind and not funder.aggregate.grants_org %}
+        <div class="media-card__box">
+            <strong>Grants To Individuals</strong> <br />
+            {{funder.aggregate.grants_ind | get_amount }}
+        </div>
+        {% endif %}
         <div class="media-card__box">
             <strong>Earliest Award</strong> <br />
             {{funder.aggregate.minAwardDate | get_date }}
@@ -24,26 +35,73 @@
             <strong>Latest Award</strong> <br />
             {{funder.aggregate.maxAwardDate | get_date }}
         </div>
-        {% if funder.stats_by_currency|length == 1 %}
-        {% for stat in funder.stats_by_currency %}
-        <div class="media-card__box">
-            <strong> Total Grants {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
-            {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
-        </div>
-        <div class="media-card__box">
-            <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
-            {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
-        </div>
-        <div class="media-card__box">
-            <strong> Smallest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
-            {{stat.currency | currency_symbol}}{{stat.min | get_amount}} <br/>
-        </div>
-        {% endfor %}
+        {# Funds either orgs or indv but not both #}
+        {% if funder.aggregate.grants_org == 0 and funder.aggregate.grants_ind > 0 or funder.aggregate.grants_ind == 0 and funder.aggregate.grants_org > 0 %}
+          {% if funder.stats_by_currency|length == 1 %}
+            {% for stat in funder.stats_by_currency %}
+            <div class="media-card__box">
+                <strong> Total Amount{%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
+            </div>
+            <div class="media-card__box">
+                <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
+            </div>
+            <div class="media-card__box">
+                <strong> Smallest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.min | get_amount}} <br/>
+            </div>
+            {% endfor %}
+          {% endif %}
         {% endif %}
     </div>
 
-    {% if funder.stats_by_currency|length > 1 %}
+    {% if funder.aggregate.currencies.keys|length == 1 %}
 
+    {% if funder.aggregate.grants_org and funder.aggregate.grants_ind %}
+    <h5>Grants to Individuals</h5>
+    {% for stat in funder.stats_by_currency %}
+      {% if stat.recipient_type == 'recipient_ind' %}
+        <div class="media-card__box_container">
+             <div class="media-card__box">
+                <strong> Total Amount{%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
+            </div>
+            <div class="media-card__box">
+                <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
+            </div>
+            <div class="media-card__box">
+                <strong> Smallest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.min | get_amount}} <br/>
+            </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+    <h5>Grants to Organisations</h5>
+    {% for stat in funder.stats_by_currency %}
+      {% if stat.recipient_type == 'recipient_org' %}
+        <div class="media-card__box_container">
+             <div class="media-card__box">
+                <strong> Total Amount{%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
+            </div>
+            <div class="media-card__box">
+                <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
+            </div>
+            <div class="media-card__box">
+                <strong> Smallest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                {{stat.currency | currency_symbol}}{{stat.min | get_amount}} <br/>
+            </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+
+
+    {% endif %}
+
+    {% elif funder.aggregate.currencies.keys|length > 1 %}
     <p>{{org_names.0}} makes grants in {{funder.stats_by_currency|length}} currencies.</p>
 
     <table class="table table--zebra dt-responsive generic_datatables" style="width: 100%">
@@ -54,6 +112,9 @@
             <th class="amount min-tablet-p">Total Amount</th>
             <th class="amount min-tablet-l">Greatest Amount</th>
             <th class="amount min-tablet-l">Smallest Amount</th>
+            {% if funder.grants_org and funder.grants_ind %}
+            <th class="amount min-tablet-l">Recipient Type</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -64,6 +125,9 @@
             <td>{{stat.currency | currency_symbol}}{{stat.total | get_amount}}</td>
             <td>{{stat.currency | currency_symbol}}{{stat.max | get_amount}}</td>
             <td>{{stat.currency | currency_symbol}}{{stat.min | get_amount}}</td>
+            {% if funder.grants_org and funder.grants_ind %}
+            <td>{{stat.recipient_type}}</td>
+            {% endif %}
           </tr>
         {% endfor %}
         </tbody>
@@ -83,12 +147,41 @@
     Please refer to the funder website for details of current grant programmes,
     application guidelines and eligibility criteria.</p>
 
-
-    <p>This table shows the recipients who have received grants made by {{org_names.0}}.</p>
-
+    {% if funder.aggregate.individual_recipients.grants > 0 %}
     <div class="section">
+      <h4>Recipient Individuals</h4>
+      <p>{{org_names.0}} funds the following grants to individuals.</p>
+      <div class="media-card__box_container">
+        <div class="media-card__box">
+            <strong>Grants</strong> <br />
+            {{funder.aggregate.individual_recipients.grants | get_amount }} <br/>
+        </div>
+
+        <div class="media-card__box">
+            <strong>Total Amount</strong> <br />
+            £{{funder.aggregate.individual_recipients.total | get_amount }} <br/>
+        </div>
+
+        <div class="media-card__box">
+            <strong>Greatest Amount</strong> <br />
+            £{{funder.aggregate.individual_recipients.max | get_amount }} <br/>
+        </div>
+
+        <div class="media-card__box">
+            <strong>Smallest Amount</strong> <br />
+            £{{funder.aggregate.individual_recipients.min | get_amount }} <br/>
+        </div>
+
+      </div>
+    </div>
+    {% endif %}
+
+    {% if funder.aggregate.grants_org %}
+    <div class="section">
+      <h4>Recipient Organisations</h4>
+        <p>This table shows the recipient organisations who have received grants made by {{org_names.0}}.</p>
         <div class="grantnav-datatable__content--filters margin-top:05">
-        <h4>Recipients</h4>
+        <div><!-- grid item --></div>
         <div class="export-wrapper">
             <div class="export-label">Export search data:</div>
 
@@ -101,7 +194,7 @@
             </div>
         </div>
         </div>
-        <div class="table table--zebra">
+        <div class="table table--zebra margin-top:1">
         <table class="table table--zebra table--small dt-responsive" id="recipients_datatable" style="width: 100%">
             <thead>
             <tr>
@@ -115,6 +208,7 @@
         </table>
         </div>
     </div>
+    {% endif %}
 
     <div class="spacer-1"></div>
 </div>

--- a/grantnav/frontend/templates/components/org-page-funder.html
+++ b/grantnav/frontend/templates/components/org-page-funder.html
@@ -8,10 +8,12 @@
     <p>{{org_names.0}} appears in the 360Giving data as a funder of grants.
     Here is an overview of the grants they have funded.</p>
     <div class="media-card__box_container">
+        {% if funder.aggregate.grants_org and funder.aggregate.grants_ind %}
         <div class="media-card__box">
-            <strong>Total Grants</strong> <br />
+            <strong>All Grants</strong> <br />
             <span style="word-break: break-all">{{funder.aggregate.grants | get_amount }}</span>
         </div>
+        {% endif %}
         {# Only funds grants to org #}
         {% if funder.aggregate.grants_org and not funder.aggregate.grants_ind %}
         <div class="media-card__box">
@@ -44,7 +46,7 @@
                 {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
             </div>
             <div class="media-card__box">
-                <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                <strong> Largest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
                 {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
             </div>
             <div class="media-card__box">
@@ -64,11 +66,15 @@
       {% if stat.recipient_type == 'recipient_ind' %}
         <div class="media-card__box_container">
              <div class="media-card__box">
+                <strong> Grants</strong> <br />
+                {{funder.aggregate.grants_ind | get_amount}}
+             </div>
+             <div class="media-card__box">
                 <strong> Total Amount{%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
                 {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
             </div>
             <div class="media-card__box">
-                <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                <strong> Largest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
                 {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
             </div>
             <div class="media-card__box">
@@ -78,16 +84,20 @@
         </div>
       {% endif %}
     {% endfor %}
-    <h5>Grants to Organisations</h5>
+    <h5>Recipient Organisations</h5>
     {% for stat in funder.stats_by_currency %}
       {% if stat.recipient_type == 'recipient_org' %}
         <div class="media-card__box_container">
+             <div class="media-card__box">
+                <strong> Grants</strong> <br />
+                {{funder.aggregate.grants_org | get_amount}}
+            </div>
              <div class="media-card__box">
                 <strong> Total Amount{%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
                 {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
             </div>
             <div class="media-card__box">
-                <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+                <strong> Largest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
                 {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
             </div>
             <div class="media-card__box">
@@ -110,7 +120,7 @@
             <th class="all">Currency</th>
             <th class="min-tablet-p">Grants</th>
             <th class="amount min-tablet-p">Total Amount</th>
-            <th class="amount min-tablet-l">Greatest Amount</th>
+            <th class="amount min-tablet-l">Largest Amount</th>
             <th class="amount min-tablet-l">Smallest Amount</th>
             {% if funder.grants_org and funder.grants_ind %}
             <th class="amount min-tablet-l">Recipient Type</th>
@@ -163,7 +173,7 @@
         </div>
 
         <div class="media-card__box">
-            <strong>Greatest Amount</strong> <br />
+            <strong>Largest Amount</strong> <br />
             £{{funder.aggregate.individual_recipients.max | get_amount }} <br/>
         </div>
 

--- a/grantnav/frontend/templates/components/org-page-recipient.html
+++ b/grantnav/frontend/templates/components/org-page-recipient.html
@@ -28,7 +28,7 @@
             {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
         </div>
         <div class="media-card__box">
-            <strong> Greatest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
+            <strong> Largest Amount {%if stat.currency != 'GBP'%} ({{stat.currency}}) {% endif %}</strong> <br />
             {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
         </div>
         <div class="media-card__box">
@@ -49,7 +49,7 @@
             <th class="all">Currency</th>
             <th class="min-tablet-p">Grants</th>
             <th class="amount min-tablet-p">Total Amount</th>
-            <th class="amount min-tablet-l">Greatest Amount</th>
+            <th class="amount min-tablet-l">Largest Amount</th>
             <th class="amount min-tablet-l">Smallest Amount</th>
           </tr>
         </thead>

--- a/grantnav/frontend/templates/components/recipient-search-result.html
+++ b/grantnav/frontend/templates/components/recipient-search-result.html
@@ -27,7 +27,7 @@
           {{stat.currency | currency_symbol}}{{stat.total | get_amount}}
         </div>
         <div class="grant-search-result__box" style="padding-bottom:0">
-          <strong>Greatest {%if stat.currency != 'GBP' or result.stats_by_currency|length > 1 %} <br /><small>{{stat.currency}}</small> {% endif %}</strong><br/>
+          <strong>Largest{%if stat.currency != 'GBP' or result.stats_by_currency|length > 1 %} <br /><small>{{stat.currency}}</small> {% endif %}</strong><br/>
           {{stat.currency | currency_symbol}}{{stat.max | get_amount}}
         </div>
         <div class="grant-search-result__box" style="padding-bottom:0">

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -1107,7 +1107,7 @@ def get_funder_info(funder_org_ids):
     results = get_results(query, 0)
 
     output = {'funder_publisher': {},
-              'recipients': results['aggregations']['recipient_orgs']['value']}
+              'recipient_orgs': results['aggregations']['recipient_orgs']['value']}
     try:
         output['funder_publisher'] = provenance.by_identifier[provenance.identifier_from_filename(results['aggregations']['filenames']['buckets'][0]['key'])]['publisher']
     except (KeyError, IndexError):

--- a/grantnav/frontend/views.py
+++ b/grantnav/frontend/views.py
@@ -1086,7 +1086,6 @@ def augment_org(org):
     org["stats_by_currency"] = org_utils.new_stats_by_currency(org)
     org["org_ids"] = org_utils.new_org_ids(org)
     org["names"] = org_utils.new_ordered_names(org)
-    org["main_currency"] = org["stats_by_currency"][0]['currency']
     return org
 
 


### PR DESCRIPTION
This adds the organisation page stats per currency and also updates the summary information in the funder search results.

<img width="1244" height="1223" alt="image" src="https://github.com/user-attachments/assets/2e3633c9-22e7-4d1a-be7e-3c4b80ea7bd0" />


<img width="1111" height="933" alt="image" src="https://github.com/user-attachments/assets/1a5663c7-d919-4953-a29a-1dec551ef7c1" />

<img width="1111" height="933" alt="image" src="https://github.com/user-attachments/assets/228833c3-be5d-4da3-9586-9da68fbaa8c6" />

<img width="1111" height="933" alt="image" src="https://github.com/user-attachments/assets/1e2161f1-941d-4d15-9d19-f1548d9b8bb6" />

