### PR TITLE
frontend: templates: components: search-summary-box: remove elements

### DIFF
--- a/grantnav/frontend/templates/components/search-summary-box.html
+++ b/grantnav/frontend/templates/components/search-summary-box.html
@@ -7,33 +7,9 @@
       <div class="search-summary--title">
         <span>Search summary</span>
       </div>
-    <div class="search-summary--description">
-      <span>To visualise the results of your search, open in
-        <a href="{{insights_base_url}}/?{{ query_string }}" title="View search results in GrantVis data visualiser" data-testid="insights-integration-btn">
-          GrantVis
-        </a>
-      </span>
-    </div>
     </header>
 
     <main class="search-summary--main">
-      <div class="search-summary--main__left-column">
-        <div class="graph-item">
-          <div class="graph-label">Amount awarded</div>
-          <div class="graph-container" style="display: inline">
-            {% amount_awarded_graph %}
-          </div>
-        </div>
-
-        <div class="graph-item">
-          <div class="graph-label">Date awarded</div>
-          <div class="graph-container" style="display: inline">
-            {% award_date_graph %}
-          </div>
-        </div>
-
-      </div>
-
 
       <div class="search-summary--main__right-column">
         <div class="summary-content--item">
@@ -57,119 +33,21 @@
         <div class="summary-content--item">
           <span>Latest grant: {{results.aggregations.latest_grant.hits.hits.0|get:"_source"|get:"awardDate"|get_date}}</span>
         </div>
+        <div class="summary-content--item">
+          {% with total_other=buckets|first|get:"amount_stats"|get:"count"|reverse_minus:results.hits.total.value %}
+            <span>Total non-{{currency}} grants:</span>
+            {% if total_other %}
+              <a href="#other-currencies-modal" class="javascript-enabled modal__trigger" id="other-currencies-modal" data-id="summary-info-model">
+                <span>{{total_other|get_amount}}</span>
+              </a>
+            {% else %}
+              0
+            {% endif %}
+          {% endwith %}
+        </div>
         <div class="summary-illustration">{% include './summary-illustration.html' %}</div>
       </div>
     </main>
-
-    <footer class="search-summary--footer">
-      <details class="search-summary--footer__details">
-        <summary>
-          <span class="summary-label">Show highlighted grants</span>
-          <span class="summary-icon" aria-hidden="true">
-            <svg width="15" height="9" viewBox="0 0 15 9" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M13.5715 2L7.73867 7.66956L2 2.0128" stroke="#153634" stroke-width="2" stroke-miterlimit="10" stroke-linecap="square" stroke-linejoin="round"/>
-            </svg>
-          </span>
-        </summary>
-        <div class="summary-footer--content">
-          <div class="summary-footer--item">
-            <span class="summary-footer--item__label">Largest grant:</span>
-            <span class="summary-footer--item__value">
-              {{currency|currency_symbol}}{{buckets|first|get:"largest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"amountAwarded"|human_format}}
-              from
-              <a href="grant/{{buckets|first|get:"largest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"id"}}">
-                {{buckets|first|get:"largest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"fundingOrganization"|first|get:"name"}}
-              to
-              {% with recipientOrganization_to=buckets|first|get:"largest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"recipientOrganization" %}
-                {% if recipientOrganization_to  %}
-                  {{recipientOrganization_to|first|get:"name"}}
-                {% else %}
-                  Individual
-                {% endif %}
-              {% endwith %}
-              </a>
-              ({{buckets|first|get:"largest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"awardDate"|get_year}})
-            </span>
-          </div>
-          {% if buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"amountAwarded" > 0 %}
-            <div class="summary-footer--item">
-              <span class="summary-footer--item__label">Smallest grant:</span>
-              <span class="summary-footer--item__value">
-                {{currency|currency_symbol}}{{buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"amountAwarded"|human_format}}
-                from
-                <a href="grant/{{buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"id"}}">
-                  {{buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"fundingOrganization"|first|get:"name"}}
-                to
-                {% with recipientOrganization_to=buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"recipientOrganization" %}
-                 {% if recipientOrganization_to %}
-                    {{recipientOrganization_to|first|get:"name"}}
-                  {% else %}
-                    Individual
-                  {% endif %}
-                {% endwith %}
-                  </a>
-                ({{buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"awardDate"|get_year}})
-              </span>
-            </div>
-          {% endif %}
-
-          <div class="summary-footer--item">
-            <span class="summary-footer--item__label">Most recent grant:</span>
-            <span class="summary-footer--item__value">
-              {{currency|currency_symbol}}{{results.aggregations.latest_grant.hits.hits.0|get:"_source"|get:"amountAwarded"|human_format}}
-              from
-              <a href="grant/{{results.aggregations.latest_grant.hits.hits.0|get:"_source"|get:"id"}}">
-                {{results.aggregations.latest_grant.hits.hits.0|get:"_source"|get:"fundingOrganization"|first|get:"name"}}
-              to
-              {% with recipientOrganization_to=results.aggregations.latest_grant.hits.hits.0|get:"_source"|get:"recipientOrganization" %}
-                {% if recipientOrganization_to %}
-                  {{recipientOrganization_to|first|get:"name"}}
-                {% else %}
-                  Individual
-                {% endif %}
-              {% endwith %}
-              </a>
-              ({{results.aggregations.latest_grant.hits.hits.0|get:"_source"|get:"awardDate"|get_year}})
-              </span>
-            </div>
-          <div class="summary-footer--item">
-            <span class="summary-footer--item__label">Oldest grant:</span>
-            <span class="summary-footer--item__value">
-              {{currency|currency_symbol}}{{results.aggregations.earliest_grant.hits.hits.0|get:"_source"|get:"amountAwarded"|human_format}}
-              from
-              <a href="grant/{{results.aggregations.earliest_grant.hits.hits.0|get:"_source"|get:"id"}}">
-                {{results.aggregations.earliest_grant.hits.hits.0|get:"_source"|get:"fundingOrganization"|first|get:"name"}}
-              to
-              {% with recipientOrganization_to=results.aggregations.earliest_grant.hits.hits.0|get:"_source"|get:"recipientOrganization" %}
-                {% if recipientOrganization_to %}
-                  {{recipientOrganization_to|first|get:"name"}}
-                {% else %}
-                  Individual
-                {% endif %}
-              {% endwith %}
-               </a>
-              ({{results.aggregations.earliest_grant.hits.hits.0|get:"_source"|get:"awardDate"|get_year}})
-              </span>
-          </div>
-          <div class="summary-footer--item">
-              {% with total_other=buckets|first|get:"amount_stats"|get:"count"|reverse_minus:results.hits.total.value %}
-                <span class="summary-footer--item__label">Total non-{{currency}} grants:</span>
-                {% if total_other %}
-                  <a href="#other-currencies-modal" class="javascript-enabled modal__trigger" id="other-currencies-modal" data-id="summary-info-model">
-                    <span class="summary-footer--item__value">{{total_other|get_amount}}</span>
-                  </a>
-                {% else %}
-                  0
-                {% endif %}
-              {% endwith %}
-          </div>
-          {% if buckets|first|get:"smallest_grant"|get:"hits"|get:"hits"|first|get:"_source"|get:"amountAwarded" > 0 %}
-          <div class="summary-footer--item">
-          </div>
-          {% endif %}
-        </div>
-      </details>
-    </footer>
 
   {% endwith %}
 </section>

--- a/tests/tests_browser.py
+++ b/tests/tests_browser.py
@@ -62,9 +62,6 @@ class InteractionsTests(BrowserTestCase):
             ).text
         )
 
-        # open show highlighted grants section
-        self.browser.find_element(By.CLASS_NAME, "summary-icon").click()
-
         # other_currencies_modal = browser.find_element(By.ID, "other-currencies-modal")
         # search "laboratory"
         other_currencies_modal = self.browser.find_element(


### PR DESCRIPTION
https://github.com/ThreeSixtyGiving/grantnav/issues/1197

I have moved "Total non-GBP grants" from "highlighted grants" to the "Search summary" as it is the only data. I can move it back.

<img width="1125" height="385" alt="Screenshot 2026-01-14 at 12 25 17" src="https://github.com/user-attachments/assets/7a36e04e-e6d1-48d8-984c-402d58c2d9e7" />

<img width="892" height="583" alt="Screenshot 2026-01-14 at 12 31 52" src="https://github.com/user-attachments/assets/b49cbef9-a8e0-4035-acb0-666316bd539b" />
