### PR TITLE
search-summary-box: delete image and add back the year chart

### DIFF
--- a/grantnav/frontend/templates/components/search-summary-box.html
+++ b/grantnav/frontend/templates/components/search-summary-box.html
@@ -10,6 +10,14 @@
     </header>
 
     <main class="search-summary--main">
+      <div class="search-summary--main__left-column">
+        <div class="graph-item">
+          <div class="graph-label">Date awarded</div>
+          <div class="graph-container" style="display: inline">
+            {% award_date_graph %}
+          </div>
+        </div>
+      </div>
 
       <div class="search-summary--main__right-column">
         <div class="summary-content--item">
@@ -45,7 +53,6 @@
             {% endif %}
           {% endwith %}
         </div>
-        <div class="summary-illustration">{% include './summary-illustration.html' %}</div>
       </div>
     </main>
 


### PR DESCRIPTION
Related to #1197 

<img width="1533" height="375" alt="Screenshot 2026-02-17 at 10 58 08" src="https://github.com/user-attachments/assets/dcea4d23-5c65-4640-86c6-1934f02677c2" />
