### PR TITLE
Grant Search and Filter Analytics

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+# Runs a local Elasticsearch instance for developing/testing GrantNav
+# NOTE: Doesn't run GrantNav in a container, only elasticsearch
+#       You must seperately run GrantNav itsself
+
+services:
+  elasticsearch:
+    image: elasticsearch:7.17.23
+    environment:
+      "discovery.type": 'single-node'
+      "TAKE_FILE_OWNERSHIP": "True"
+      "ES_JAVA_OPTS": "-Xms2g -Xmx4g"
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    volumes:
+      - "elasticsearch_data:/usr/share/elasticsearch/data/"
+
+volumes:
+   elasticsearch_data: {}

--- a/grantnav/frontend/context_processors.py
+++ b/grantnav/frontend/context_processors.py
@@ -4,8 +4,8 @@ import datetime
 from django.conf import settings
 
 
-def piwik(request):
-    return {'piwik': settings.PIWIK}
+def matomo(request):
+    return {'matomo': settings.PIWIK}
 
 
 def navigation(request):

--- a/grantnav/frontend/templates/base.html
+++ b/grantnav/frontend/templates/base.html
@@ -1,5 +1,5 @@
 {% load static %}
-<!doctype html lang="en">
+<!DOCTYPE html>
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7" lang=""> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8" lang=""> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
@@ -20,6 +20,8 @@
 
         <link rel="stylesheet" href="{% static 'css/main.css'%}?v={{ main_css_cache_key }}">
         <link rel="stylesheet" href="{% static 'css/glyphicons-halflings.css'%}">
+
+        {% include "components/analytics-js.html.j2" %}
 
         <noscript>
           <style>

--- a/grantnav/frontend/templates/components/analytics-js.html.j2
+++ b/grantnav/frontend/templates/components/analytics-js.html.j2
@@ -1,0 +1,84 @@
+{% if matomo.url and matomo.site_id %}
+<!-- Matomo -->
+<script type="text/javascript">
+    /* eslint-disable no-var */
+    console.log("GrantNav: Matomo Analytics Configured");
+    var _paq = window._paq = window._paq || [];
+    var siteID = '{{ matomo.site_id }}';
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    // only one of requireCookieConsent OR requireConsent can be set
+    // see: https://matomo.org/faq/general/faq_156/
+    _paq.push(['requireCookieConsent']); // Don't use cookies unless we have consent
+
+    // Set tracking cookie domain if one is configured
+    {% if matomo.cookie_domain %}
+        {% if matomo.cookie_subdomains %}
+            _paq.push(['setCookieDomain', '*.{{ matomo.cookie_domain }}']);
+        {% else %}
+            _paq.push(['setCookieDomain', '{{ matomo.cookie_domain }}']);
+        {% endif %}
+    {% endif %}
+
+    _paq.push(['alwaysUseSendBeacon']); // https://matomo.org/faq/how-to/faq_33087/
+    _paq.push(['setVisitorCookieTimeout', 60*60*24*90]); // Tracking cookie timeout after 90 days
+    _paq.push(['setDownloadExtensions', 'json|csv|xlsx']);
+    _paq.push(['enableHeartBeatTimer']);
+
+    // Track GrantNav searches
+    {% if results and results.hits and not search_error %}
+        var gnIsSearch = true;
+        // It's a search!
+        var gnSearchQuery = '{{ text_query }}';
+        if(!gnSearchQuery) { gnSearchQuery = '*'; }
+
+        var _urlParams = new URLSearchParams(window.location.search);
+        var gnSearchFields = _urlParams.has("default_field") ? _urlParams.get("default_field") : "*";
+        var gnSearchResultsTotal = {{ results.hits.total.value }};
+
+        // The search category is what the user is searching for, and by what
+        var gnSearchCategory = "UNKNOWN";
+
+        if (window.location.pathname === "/search")  {
+            gnSearchCategory = "Grants";
+        } else if(window.location.pathname === "/funders") {
+            gnSearchCategory = "Funders";
+        } else if(window.location.pathname === "/recipients") {
+            gnSearchCategory = "Recipients";
+        }
+
+    {% else %}
+        var gnIsSearch = false;
+    {% endif %}
+
+    _paq.push([function() {
+        var tracker = this;
+
+        // Add event trackers for search download buttons
+        var csvCustomExportModalBtn = document.getElementById('custom-csv-download-modal-btn');
+        if (csvCustomExportModalBtn) {
+            csvCustomExportModalBtn.addEventListener('click', function(e) {
+                tracker.trackEvent('GrantNavUI', 'Clicked', 'CustomCSVModalOpened');
+            });
+        }
+    }]);
+
+    // Track the page view or search
+    if(gnIsSearch) {
+        _paq.push(['trackSiteSearch', gnSearchQuery, gnSearchCategory, gnSearchResultsTotal]);
+    } else {
+        _paq.push(['trackPageView']);
+    }
+
+    _paq.push(['enableLinkTracking']);
+
+    (function () {
+        var u = '{{ matomo.url }}';
+        _paq.push(['setTrackerUrl', u + 'matomo.php']);
+        if (!siteID) throw new Error('siteID not set');
+        _paq.push(['setSiteId', siteID]);
+        var d = document; var g = d.createElement('script'); var s = d.getElementsByTagName('script')[0];
+        g.type = 'text/javascript'; g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+    })();
+</script>
+<!-- End Matomo Code -->
+{% endif %}

--- a/grantnav/frontend/templates/components/cookie-consent.html
+++ b/grantnav/frontend/templates/components/cookie-consent.html
@@ -1,26 +1,3 @@
-{% if not debug %}
-<!-- Matomo -->
-<script type="text/javascript">
-  /* eslint-disable no-var */
-  var _paq = window._paq = window._paq || [];
-  var siteID = 9;
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['requireCookieConsent']); // Don't use cookies unless we have consent
-  _paq.push(['setCookieDomain', '*.threesixtygiving.org']);
-  _paq.push(['setDownloadExtensions', 'json|csv|xlsx']);
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function () {
-    var u = 'https://analytics.threesixtygiving.org/';
-    _paq.push(['setTrackerUrl', u + 'matomo.php']);
-    if (!siteID) throw new Error('siteID not set');
-    _paq.push(['setSiteId', siteID]);
-    var d = document; var g = d.createElement('script'); var s = d.getElementsByTagName('script')[0];
-    g.type = 'text/javascript'; g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
-  })();
-</script>
-<!-- End Matomo Code -->
-
 <script type="text/javascript">
   function hideCookieConsentDialog (hide) {
     if (hide) {
@@ -32,12 +9,14 @@
 
   // eslint-disable-next-line no-unused-vars
   function noCookieConsent () {
-    document.cookie = 'noEnhancedAnalytics=1; max-age=2592000; domain=threesixtygiving.org';
+    document.cookie = 'noEnhancedAnalytics=1; max-age=7776000; domain={{ matomo.cookie_domain }}';
   }
 
   document.addEventListener('DOMContentLoaded', function () {
+    // Has a consent preference cookie already been set?
     if (document.cookie.indexOf('mtm_cookie_consent') > -1 ||
       document.cookie.indexOf('mtm_consent_removed') > -1 ||
+      document.cookie.indexOf('mtm_consent') > -1 ||
       document.cookie.indexOf('noEnhancedAnalytics') > -1) {
       hideCookieConsentDialog(true);
     } else {
@@ -53,11 +32,9 @@
           Policy</a>
       </h2>
       <p class="base-card__text">
-        <a href="#" onclick="_paq.push(['rememberCookieConsentGiven']); hideCookieConsentDialog(true);"
-          class="button">Yes</a>
-        <a href="#" onclick="noCookieConsent(); hideCookieConsentDialog(true);" class="button cookie-consent-no">No</a>
-        <a href="#" onclick="_paq.push(['optUserOut']); hideCookieConsentDialog(true);" class="button">Disable
-          Analytics</a>
+        <a href="#" onclick="_paq.push(['rememberCookieConsentGiven']); hideCookieConsentDialog(true);" class="button">Yes</a>
+        <a href="#" onclick="_paq.push(['forgetCookieConsentGiven']); noCookieConsent(); hideCookieConsentDialog(true);" class="button cookie-consent-no">No</a>
+        <a href="#" onclick="_paq.push(['optUserOut']); hideCookieConsentDialog(true);" class="button">Disable Analytics</a>
       </p>
       <p id="cookie-dialog-desc" style="font-style: italic;">360Giving uses privacy-respecting analytics. If you don't
         accept cookies, we will track only basic information about your visit. Click "Disable Analytics" if you don't
@@ -65,4 +42,3 @@
     </div>
   </div>
 </div>
-{% endif %}

--- a/grantnav/frontend/templates/components/download-data.html
+++ b/grantnav/frontend/templates/components/download-data.html
@@ -2,14 +2,14 @@
 
 <div style="display:flex; flex-direction: row; align-items:center; justify-content: end; gap: 6px">
 
-  <a class="grantnav-search__content--insights-large button button--large button--teal-dark bold margin-left:4" style="margin-right: 6rem" href="{{insights_base_url}}/?{{ query_string }}" title="View search results in GrantVis data visualiser" data-testid="insights-integration-btn">
+  <a id="visualise-search-in-grantvis-btn" class="grantnav-search__content--insights-large button button--large button--teal-dark bold margin-left:4" style="margin-right: 6rem" href="{{insights_base_url}}/?{{ query_string }}" title="View search results in GrantVis data visualiser" data-testid="insights-integration-btn">
     Visualise your search results in GrantVis
   </a>
 
   <h4 class="margin-right:1">Download Results:</h4>
 
 	<div class="export-button" style="text-align:center">
-		<a class="export-data-button export-data-button--json" href="{% url 'search.json' %}?{{ query_string }}"
+		<a id="direct-json-download-btn" class="export-data-button export-data-button--json" href="{% url 'search.json' %}?{{ query_string }}"
 			title="Export search results as JSON data">
 			{% include 'tokens/export-json-icon.html' %}
 		</a>

--- a/grantnav/settings.py
+++ b/grantnav/settings.py
@@ -27,8 +27,10 @@ if 'SECRET_KEY' not in os.environ:
 env = environ.Env(  # set default values and casting
     SENTRY_DSN=(str, ''),
     DEBUG=(bool, False),
-    PIWIK_URL=(str, ''),
+    PIWIK_URL=(str, 'https://analytics.threesixtygiving.org/'),
     PIWIK_SITE_ID=(str, ''),
+    MATOMO_COOKIE_DOMAIN=(str, 'threesixtygiving.org'),
+    MATOMO_COOKIE_SUBDOMAINS=(bool, True),
     ALLOWED_HOSTS=(list, []),
     SECRET_KEY=(str, secret_key),
     GRANT_SCHEMA=(str, 'https://raw.githubusercontent.com/ThreeSixtyGiving/standard/main/schema/360-giving-schema.json'),
@@ -44,6 +46,8 @@ env = environ.Env(  # set default values and casting
 PIWIK = {
     'url': env('PIWIK_URL'),
     'site_id': env('PIWIK_SITE_ID'),
+    'cookie_domain': env('MATOMO_COOKIE_DOMAIN'),
+    'cookie_subdomains': env('MATOMO_COOKIE_SUBDOMAINS'),
 }
 
 # Plotly
@@ -114,7 +118,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'grantnav.frontend.context_processors.piwik',
+                'grantnav.frontend.context_processors.matomo',
                 'grantnav.frontend.context_processors.navigation',
                 'grantnav.frontend.context_processors.main_css_cache_key',
                 'grantnav.frontend.context_processors.debug_mode',

--- a/grantnav/settings_dev_analytics.py
+++ b/grantnav/settings_dev_analytics.py
@@ -1,0 +1,19 @@
+# These settings redirect the matomo analytics to a local dev instance
+# Helpful for developing the analytics code
+
+from .settings import * # noqaa
+
+DEBUG = True
+
+SECRET_KEY = 'itsasecret'
+
+PIWIK = {
+    'url': "//localhost:8090/",
+    'site_id': '1',
+    'cookie_domain': '',
+    'cookie_subdomains': False,
+}
+
+INSIGHTS_BASE_URL = "http://localhost:8081"
+
+DISABLE_COOKIE_POPUP = False


### PR DESCRIPTION
General analytics code improvements to be more explicit (in code) about what gets tracked how, and adding metadata about searches.

This PR:
 * Moves analytics-specific JavaScript to a seperate template file
 * Explitily tracks Searches on GrantNav, rather than letting Matomo (unreliably) try to infer searches vs pageviews
 * Explicitly handles tracking cookie consent
 * Tracks clicks of the Custom CSV modal
 * Enable the heartbeat timer, so we know how long users spent on various pages
 * Improves the experience for locally testing analytics